### PR TITLE
run: hook server which can parse `DNSbackend` and `listen ips`

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,22 +1,27 @@
 //! Runs the aardvark dns server with provided config
+use crate::server::serve;
 use clap::{self, Clap};
 use log::debug;
-use core::fmt::Error;
+use std::io::Error;
 
 #[derive(Clap, Debug)]
-pub struct Run {
-}
+pub struct Run {}
 
 impl Run {
     /// The run command runs the aardvark-dns server with the given configuration.
     pub fn new() -> Self {
-        Self {
-        }
+        Self {}
     }
 
     pub fn exec(&self, input_file: String) -> Result<(), Error> {
-        debug!("{:?} with input file from {:?}", "Setting up...", input_file);
-        Ok(())
+        debug!("Setting up aardvark server with input as {:?}", input_file);
 
+        if let Err(er) = serve::serve(&input_file) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("Error starting server {}", er),
+            ));
+        }
+        Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-pub mod commands;
 pub mod backend;
+pub mod commands;
 pub mod config;
 pub mod server;

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,9 +31,9 @@ fn main() {
 
     match result {
         Ok(_) => {}
-        Err(_err) => {
+        Err(err) => {
+            println!("{}", err);
             std::process::exit(1);
         }
     }
 }
-

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,4 +1,2 @@
 // Serve DNS requests on the given bind addresses.
-pub fn server(_config_path: &str) -> Result<(), std::io::Error> {
-    todo!();
-}
+pub mod serve;

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -1,0 +1,19 @@
+use crate::config;
+use log::debug;
+
+pub fn serve(_config_path: &str) -> Result<(), std::io::Error> {
+    match config::parse_configs(_config_path) {
+        Ok((_backend, listen_ip_v4, listen_ip_v6)) => {
+            debug!("Successfully parsed config");
+            debug!("Listen v4 ip {:?}", listen_ip_v4);
+            debug!("Listen v6 ip {:?}", listen_ip_v6);
+        }
+        Err(e) => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("unable to parse config: {}", e),
+            ))
+        }
+    }
+    todo!();
+}


### PR DESCRIPTION
Implement `aardvark-dns --file <config> run` to actually parse and run server