### PR TITLE
dns: allow `underscore` in record origin, fallback to `utf8` instead of `IDNA` parsing

### DIFF
--- a/src/dns/coredns.rs
+++ b/src/dns/coredns.rs
@@ -69,7 +69,10 @@ impl CoreDns {
     }
 
     pub fn update_record(&mut self, name: &str, addr: IpAddr, ttl: u32) {
-        let origin: Name = Name::parse(name.clone(), None).unwrap();
+        //Note: this is important we must accept `_` underscore in record name.
+        // If IDNA fails try parsing with utf8, this is `RFC 952` breach but expected.
+        // Accept create origin name from str_relaxed so we could use underscore
+        let origin: Name = Name::from_str_relaxed(name).unwrap();
         match addr {
             IpAddr::V4(ipv4) => {
                 self.authority.upsert(


### PR DESCRIPTION
We need dns server to be able to understand `underscore` in record
names. So fallback to `utf8` if `IDNA` fails and try using record name
anyhow.

References:
https://datatracker.ietf.org/doc/html/rfc952
https://www.iana.org/assignments/idna-tables-6.3.0/idna-tables-6.3.0.xhtml
https://datatracker.ietf.org/doc/html/rfc5890#section-2.3.1