### PR TITLE
backend: resolve fully qualified domain names ( `FQDN` ) as regular container entries

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -54,7 +54,7 @@ impl DNSBackend {
     // TODO: right now this returns v4 and v6 addresses intermixed and relies on
     // the caller to sort through them; we could add a v6 bool as an argument
     // and do it here instead.
-    pub fn lookup(&self, requester: &IpAddr, name: &str) -> DNSResult {
+    pub fn lookup(&self, requester: &IpAddr, mut name: &str) -> DNSResult {
         let nets = match self.ip_mappings.get(requester) {
             Some(n) => n,
             None => return DNSResult::NoSuchIP,
@@ -70,6 +70,10 @@ impl DNSBackend {
                     continue;
                 }
             };
+            // if this is a fully qualified name, remove dots so backend can perform search
+            if name.len() > 0 && name.chars().last().unwrap() == '.' {
+                name = &name[0..name.len() - 1];
+            }
             if let Some(addrs) = net_names.get(name) {
                 results.append(&mut addrs.clone());
             }

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -1,7 +1,7 @@
 use crate::backend::DNSBackend;
 use crate::config;
 use crate::dns::coredns::CoreDns;
-use log::{debug, info};
+use log::{debug, error, info};
 use signal_hook::consts::signal::SIGHUP;
 use signal_hook::iterator::Signals;
 use std::net::IpAddr;
@@ -65,6 +65,7 @@ fn core_serve_loop(_config_path: &str, port: u32) -> Result<(), std::io::Error> 
                             kill_switch_arc_clone,
                             port,
                         ) {
+                            error!("Unable to start server {}", _e);
                             return Err(std::io::Error::new(
                                 std::io::ErrorKind::Other,
                                 format!("Error while invoking start_dns_server: {}", _e),


### PR DESCRIPTION
Backend must treat fully qualified domain names as regular entries,
since container names don't following qualified domain names but we get
them as fully qualified domain names which is not applicable for backend.
