### PR TITLE
config, server: generate aardvark `pid` files for interprocess signaling

### DIFF
--- a/src/config/constants.rs
+++ b/src/config/constants.rs
@@ -1,0 +1,1 @@
+pub static AARDVARK_PID_FILE: &str = "aardvark.pid";

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::fs::{metadata, read_dir, read_to_string};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::vec::Vec;
+pub mod constants;
 
 // Parse configuration files in the given directory.
 // Configuration files are formatted as follows:
@@ -50,6 +51,11 @@ pub fn parse_configs(
         // rate.
         match config {
             Ok(cfg) => {
+                // dont process aardvark pid files
+                // unwrap is safe here since file already exists
+                if cfg.path().file_name().unwrap() == constants::AARDVARK_PID_FILE {
+                    continue;
+                }
                 let (bind_ips, ctr_entry) = parse_config(&(cfg.path().as_path()))?;
 
                 let network_name: String = match cfg.path().file_name() {


### PR DESCRIPTION
Other process send Signals to aardvark's process hence they need access
to aardvark's `pid`. Therefore on every run aardvark will create `pid`
files on the specified config.

If aardvark ever crash and restarts it will automatically update its `pid` file with
new `pid`.
