### PR TITLE
Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2018"
 authors = ["github.com/containers"]
 description = "A container-focused DNS server"
+exclude = ["/.cirrus.yml", "/.github/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Also exclude .cirrus.yml and .github dir from Cargo.toml
for any future shipment as a crate.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@flouthoc @baude @mheon PTAL