### PR TITLE
Makefile: install target shouldn't call build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ clean:
 #	$(MAKE) -C docs
 
 .PHONY: install
-install: docs build
+install:
 	install ${SELINUXOPT} -D -m0755 bin/aardvark-dns $(DESTDIR)/$(LIBEXECPODMAN)/aardvark-dns
 	#$(MAKE) -C docs install
 


### PR DESCRIPTION
This would imply `make && make install` for people building from source.
It would also save the Makefile from getting polluted with `-nobuild`
targets.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@flouthoc @baude @mheon @Luap99 @rhatdan PTAL.