### PR TITLE
Fix leaking pid file fd and remove pid file on exit 

### DIFF
--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -52,6 +52,10 @@ pub fn serve(config_path: &str, port: u32) -> Result<(), std::io::Error> {
         Ok(_) => {}
     }
 
+    // rust closes the fd only when it leaves the scope, since this is
+    // the main loop it will never happen so we have to manually close it
+    drop(pid_file);
+
     loop {
         if let Err(er) = core_serve_loop(config_path, port) {
             return Err(std::io::Error::new(


### PR DESCRIPTION
Rust closes the fd only when it leaves the scope, since this is
the main loop it will never happen so we have to manually close it.
Also we should not leak the pid file on exit.
