### PR TITLE
dns, server: don't trigger kill_switch inside receiver block instead move it to parent `event loop`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ else
 endif
 
 .PHONY: all
-all: vendor build
+all: build
 
 bin:
 	mkdir -p $@

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -166,6 +166,8 @@ fn core_serve_loop(config_path: &str, port: u32) -> Result<(), std::io::Error> {
                 *switch = true;
 
                 // kill servers
+                // TODO: we don't need these two loops anymore. But lets remove when some testing
+                // is done.
                 for (network_name, listen_ip_list) in listen_ip_v4_clone {
                     debug!("Refreshing all servers for network {:?}", network_name);
                     for ip in listen_ip_list {
@@ -182,8 +184,10 @@ fn core_serve_loop(config_path: &str, port: u32) -> Result<(), std::io::Error> {
                 }
             }
 
-            // Don't wait for child threads since interface can be removed before
-            // as  well in some environments. Just rely on kill swtich to kill threads.
+            for handle in thread_handles {
+                let _ = handle.join().unwrap();
+            }
+
             return Ok(());
         }
         Err(e) => {


### PR DESCRIPTION
    Why ?
    It seems there is a race if interface is removed from below before we stop event loop and closing
    sockets won't stop the event loop. So lets de-couple thread killing from any network code.
    
    Solution:
    Receiver is already async so leverage that and move kill_switch to an
    event loop which is not dependent on receiver.
    
    Following solution makes sure that our thread management is not
    dependent on any networking code. If we want to kill the thread we can
    kill it.
