### PR TITLE
Bump to v1.0.0-rc1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # aardvark-dns
 
 Authoritative dns server for `A/AAAA` container records. Forwards other request to configured resolvers.
-Read more about configuration in `src/backend/mod.rs`.
+Read more about configuration in `src/backend/mod.rs`. It is mostly intended to be used with
+[Netavark](https://github.com/containers/netavark/) which will launch it automatically if both are
+installed.
 
 ```console
 aardvark-dns 0.1.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,4 @@
+# Release Notes
+
+## v1.0.0-RC1
+- This is the first release candidate of Aardvark's initial release! All major functionality is implemented and working.


### PR DESCRIPTION
I wanted to get a manpage written, but I'm giving up for now, getting all the Makefile shenanigans for go-md2man working was trying my patience.

Add a release notes document, and update readme a bit to point to Netavark.

Still to do in a future release: integrate version into Aardvark itself, so we have a command that prints current version.