### PR TITLE
dns: add support to whiteout search-domain, defaults for `.dns.podman`

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -13,13 +13,18 @@ impl Run {
         Self {}
     }
 
-    pub fn exec(&self, input_dir: String, port: u32) -> Result<(), Error> {
+    pub fn exec(
+        &self,
+        input_dir: String,
+        port: u32,
+        filter_search_domain: String,
+    ) -> Result<(), Error> {
         debug!(
             "Setting up aardvark server with input directory as {:?}",
             input_dir
         );
 
-        if let Err(er) = serve::serve(&input_dir, port) {
+        if let Err(er) = serve::serve(&input_dir, port, &filter_search_domain) {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
                 format!("Error starting server {}", er),

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,9 @@ struct Opts {
     /// Host port for aardvark servers, defaults to 5533
     #[clap(short, long)]
     port: Option<u32>,
+    /// Filters search domain for backward compatiblity with dnsname/dnsmasq
+    #[clap(short, long)]
+    filter_search_domain: Option<String>,
     /// Aardvark-dns trig command
     #[clap(subcommand)]
     subcmd: SubCommand,
@@ -29,8 +32,11 @@ fn main() {
 
     let dir = opts.config.unwrap_or_else(|| String::from("/dev/stdin"));
     let port = opts.port.unwrap_or_else(|| 5533 as u32);
+    let filter_search_domain = opts
+        .filter_search_domain
+        .unwrap_or_else(|| String::from(".dns.podman"));
     let result = match opts.subcmd {
-        SubCommand::Run(run) => run.exec(dir, port),
+        SubCommand::Run(run) => run.exec(dir, port, filter_search_domain),
     };
 
     match result {


### PR DESCRIPTION
We did a workaround in dnsname/dnsmasq setup to append a default
search-domain to all dns queries. Lets support that.

By default it filter's out `dns.podman`