### PR TITLE
Cirrus: Identify precisely where binary came from

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -59,6 +59,16 @@ build_task:
     - make debug=1
     - make build_unit  # re-uses debug targets
     - make
+    # Identify where the binary came from to benefit downstream consumers.
+    - |
+        cat >> bin/aardvark-dns.info << EOF
+        repo: $CIRRUS_REPO_CLONE_URL
+        branch: $CIRRUS_BASE_BRANCH
+        title: $CIRRUS_CHANGE_TITLE
+        commit: $CIRRUS_CHANGE_IN_REPO
+        build: https://cirrus-ci.com/build/$CIRRUS_BUILD_ID
+        task: https://cirrus-ci.com/task/$CIRRUS_TASK_ID
+        EOF
   upload_caches: [ "cargo", "targets", "bin" ]
 
 


### PR DESCRIPTION
Port of https://github.com/containers/netavark/pull/191 for identical
purpose.

Signed-off-by: Chris Evich <cevich@redhat.com>