### PR TITLE
Makefile: allow installation of debug binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ clean:
 
 .PHONY: install
 install:
-	install ${SELINUXOPT} -D -m0755 bin/aardvark-dns $(DESTDIR)/$(LIBEXECPODMAN)/aardvark-dns
+	install ${SELINUXOPT} -D -m0755 bin/aardvark-dns$(if $(debug),.debug,) $(DESTDIR)/$(LIBEXECPODMAN)/aardvark-dns
 	#$(MAKE) -C docs install
 
 .PHONY: uninstall


### PR DESCRIPTION
Distro packaging needs unstripped binaries to create its debuginfo
packages.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

Similar to https://github.com/containers/netavark/pull/198 so let's do the netavark PR first.