### PR TITLE
tests: add slirp4netns to connect the host netns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ unit: $(CARGO_TARGET_DIR)
 #.PHONY: integration
 integration: $(CARGO_TARGET_DIR)
 	# needs to be run as root or with podman unshare --rootless-netns
-	AARDVARK_NO_PROXY=1 bats test/
+	bats test/
 
 .PHONY: mock-rpm
 mock-rpm:

--- a/test/100-basic-name-resolution.bats
+++ b/test/100-basic-name-resolution.bats
@@ -15,6 +15,10 @@ load helpers
 	a1_pid=$CONTAINER_NS_PID
 	run_in_container_netns "$a1_pid" "dig" "+short" "aone" "@$gw"
 	assert "$ip_a1"
+
+	run_in_container_netns "$a1_pid" "dig" "+short" "google.com" "@$gw"
+	# validate that we get an ipv4
+	assert "$output" =~ "[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+"
 }
 
 @test "basic container - dns itself with long network name" {
@@ -46,7 +50,7 @@ load helpers
 	a2_ip=$(echo "$config_a2" | jq -r .networks.podman1.static_ips[0])
 	create_container "$config_a2"
 	a2_pid="$CONTAINER_NS_PID"
-	
+
 	# Resolve container names to IPs
 	dig "$a1_pid" "atwo" "$gw"
 	assert "$a2_ip"

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -2,9 +2,10 @@
 
 # Netavark binary to run
 NETAVARK=${NETAVARK:-/usr/libexec/podman/netavark}
-AARDVARK=${AARDVARK:-./bin/aardvark-dns}
 
 TESTSDIR=${TESTSDIR:-$(dirname ${BASH_SOURCE})}
+
+AARDVARK=${AARDVARK:-$TESTSDIR/../bin/aardvark-dns}
 
 # export RUST_BACKTRACE so that we get a helpful stack trace
 export RUST_BACKTRACE=full
@@ -291,7 +292,7 @@ function gateway_from_subnet() {
 function create_netns() {
     # create a new netns and mountns and run a sleep process to keep it alive
     # we have to redirect stdout/err to /dev/null otherwise bats will hang
-    unshare -n sleep inf &>/dev/null &
+    unshare -mn sleep inf &>/dev/null &
     echo $!
 }
 
@@ -325,7 +326,7 @@ function run_in_container_netns() {
 ################
 #
 function run_in_host_netns() {
-    run_helper nsenter -n -t $HOST_NS_PID "$@"
+    run_helper nsenter -m -n -t $HOST_NS_PID "$@"
 }
 
 ################
@@ -469,6 +470,19 @@ function basic_host_setup() {
 	# unsetting does not work, it would use the default address
 	export DBUS_SYSTEM_BUS_ADDRESS=
 	AARDVARK_TMPDIR=$(mktemp -d --tmpdir=${BATS_TMPDIR:-/tmp} aardvark_bats.XXXXXX)
+
+    command -v slirp4netns || die "slirp4netns not installed"
+
+    slirp4netns -c $HOST_NS_PID tap0 &>/dev/null &
+    SLIRP4NETNS_PID=$!
+
+    # wait for slirp4netns, we could use --ready-fd but
+    # I cannot make this work because bach keeps the pipe open so we cannot wait for EOF
+    sleep 0.5
+
+    # create new resolv.conf with slirp4netns dns
+    echo "nameserver 10.0.2.3" > "$AARDVARK_TMPDIR/resolv.conf"
+    run_in_host_netns mount --bind "$AARDVARK_TMPDIR/resolv.conf" /etc/resolv.conf
 }
 
 function basic_teardown() {
@@ -485,13 +499,13 @@ function netavark_teardown() {
 }
 
 function teardown() {
-	basic_teardown
-
     # Now call netavark with all the configs and then kill the netns associated with it
     for i in "${!CONTAINER_CONFIGS[@]}"; do
         netavark_teardown $(get_container_netns_path "${CONTAINER_NS_PIDS[$i]}") "${CONTAINER_CONFIGS[$i]}"
         kill -9 "${CONTAINER_NS_PIDS[$i]}"
     done
+
+    kill -9 $SLIRP4NETNS_PID
 
     # Finally kill the host netns
     if [ ! -z "$HOST_NS_PID" ]; then
@@ -499,6 +513,7 @@ function teardown() {
         kill -9 "$HOST_NS_PID"
     fi
 
+    basic_teardown
 }
 
 function dig() {


### PR DESCRIPTION
To test upstream resolvers we need a connection to the internet. We can
use slirp4netns for this. Also create a new mount namespace so that we
can bind mount a correct resolv.conf which points to the slirp4netns
resolver.
