### PR TITLE
dns: A few minor patches

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -91,7 +91,7 @@ impl DNSBackend {
     }
 
     // reverse lookup must return a single name resolved via mapping
-    pub fn reverse_lookup(&self, requester: &IpAddr, lookup_ip: &IpAddr) -> Option<Vec<&str>> {
+    pub fn reverse_lookup(&self, requester: &IpAddr, lookup_ip: &IpAddr) -> Option<&Vec<String>> {
         let nets = match self.ip_mappings.get(requester) {
             Some(n) => n,
             None => return None,
@@ -100,7 +100,7 @@ impl DNSBackend {
         for net in nets {
             if let Some(ips) = self.reverse_mappings.get(net) {
                 if let Some(names) = ips.get(lookup_ip) {
-                    return Some(names.iter().map(|s| s.as_str()).collect());
+                    return Some(names);
                 }
             }
         }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -97,11 +97,9 @@ impl DNSBackend {
             None => return None,
         };
 
-        for net in nets {
-            if let Some(ips) = self.reverse_mappings.get(net) {
-                if let Some(names) = ips.get(lookup_ip) {
-                    return Some(names);
-                }
+        for ips in nets.iter().filter_map(|v| self.reverse_mappings.get(v)) {
+            if let Some(names) = ips.get(lookup_ip) {
+                return Some(names);
             }
         }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -90,7 +90,7 @@ impl DNSBackend {
         DNSResult::Success(results)
     }
 
-    // reverse lookup must return a single name resolved via mapping
+    /// Return a single name resolved via mapping if it exists.
     pub fn reverse_lookup(&self, requester: &IpAddr, lookup_ip: &IpAddr) -> Option<&Vec<String>> {
         let nets = match self.ip_mappings.get(requester) {
             Some(n) => n,


### PR DESCRIPTION
dns: Return fully borrowed value

This is even simpler and more efficient.

---

dns: Use triple slash function documentation

A bit better best practice.

---

dns: Use `filter_map` to lower nesting

Combinators versus explicit matching can be a bit of a taste thing;
in this case I find `filter_map()` avoids nesting and makes things
a bit clearer.

---

