### PR TITLE
tests: fix slirp flake

### DIFF
--- a/test/100-basic-name-resolution.bats
+++ b/test/100-basic-name-resolution.bats
@@ -6,6 +6,8 @@
 load helpers
 
 @test "basic container - dns itself" {
+	setup_slirp4netns
+
 	subnet_a=$(random_subnet 5)
 	create_config "podman1" $(random_string 64) "aone" "$subnet_a" "a1" "1a"
 	config_a1=$config

--- a/test/200-two-networks.bats
+++ b/test/200-two-networks.bats
@@ -7,6 +7,8 @@ load helpers
 
 
 @test "two containers on different networks" {
+	setup_slirp4netns
+
 	# container a1 on subnet a
 	subnet_a=$(random_subnet 5)
 	create_config "podman1" $(random_string 64) "aone" "$subnet_a"
@@ -86,7 +88,7 @@ load helpers
 	b2_network_info="{$new_network_info}"
 	ab2_config=$(jq -r ".networks +=  $b2_network" <<<"$a2_config")
 	ab2_config=$(jq -r ".network_info += $b2_network_info" <<<"$ab2_config")
-	
+
 	create_container "$ab2_config"
 	ab2_pid=$CONTAINER_NS_PID
 


### PR DESCRIPTION
When we create a new netns with unshare we have to wait until it
completes before using the ns. When we run things in the background with
`&` we always need to check that the process is ready before using it.
We now have ready checks for unshare and slirp4netns so it should no
longer flake even on slow systems.

Also only setup slirp4netns when needed for the test to safe some setup
time.