### PR TITLE
Make validate must not error

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -76,10 +76,6 @@ validate_task:
   bin_cache: &ro_bin_cache
     <<: *bin_cache
     reupload_on_changes: false
-  # FIXME: At the time this task was added, the code currently does not
-  # pass verification.  Somebody with rust skills should fix this, then
-  # remove the following line:
-  allow_failures: $CI == $CI
   setup_script: *setup
   main_script: *main
 


### PR DESCRIPTION
make validate cannot complete with errors is now being enforced.

Signed-off-by: Brent Baude <bbaude@redhat.com>