### PR TITLE
aardvark-dns-v1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aardvark-dns"
-version = "1.0.1-dev"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aardvark-dns"
-version = "1.0.1"
+version = "1.0.2-dev"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aardvark-dns"
-version = "1.0.1-dev"
+version = "1.0.1"
 edition = "2018"
 authors = ["github.com/containers"]
 description = "A container-focused DNS server"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aardvark-dns"
-version = "1.0.1"
+version = "1.0.2-dev"
 edition = "2018"
 authors = ["github.com/containers"]
 description = "A container-focused DNS server"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## v1.0.1
+- Remove vendor directory from upstream github repository
+- Vendored libraries updates
+
 ## v1.0.0
 - First release of aardvark-dns.
 


### PR DESCRIPTION
- update release notes
- cut release v1.0.1
- bump to 1.0.2-dev