### PR TITLE
[v1.0.1-rhel] Backport "Drop vergen dependency"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@
 # Main collection of env. vars to set for all tasks and scripts.
 env:
     # Actual|intended branch for this run
-    DEST_BRANCH: "main"
+    DEST_BRANCH: "v1.0.1-rhel"
     # The default is 'sh' if unspecified
     CIRRUS_SHELL: "/bin/bash"
     # Location where source repo. will be cloned

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-broadcast",
+ "chrono",
  "clap",
  "futures-util",
  "log",
@@ -18,7 +19,6 @@ dependencies = [
  "trust-dns-client",
  "trust-dns-proto",
  "trust-dns-server",
- "vergen",
 ]
 
 [[package]]
@@ -86,15 +86,6 @@ name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
-
-[[package]]
-name = "cc"
-version = "1.0.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
-dependencies = [
- "jobserver",
-]
 
 [[package]]
 name = "cfg-if"
@@ -170,26 +161,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595"
 dependencies = [
  "heck 0.3.3",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "enum-iterator"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
-dependencies = [
- "enum-iterator-derive",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
-dependencies = [
  "proc-macro2",
  "quote",
  "syn",
@@ -308,31 +279,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getset"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "git2"
-version = "0.13.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
-dependencies = [
- "bitflags",
- "libc",
- "libgit2-sys",
- "log",
- "url",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,15 +359,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
-name = "jobserver"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,30 +369,6 @@ name = "libc"
 version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
-
-[[package]]
-name = "libgit2-sys"
-version = "0.12.26+1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "lock_api"
@@ -628,12 +541,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,31 +670,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
-
-[[package]]
-name = "rustversion"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
-
-[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "semver"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
 
 [[package]]
 name = "serde"
@@ -1096,29 +982,6 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
-]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vergen"
-version = "6.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3893329bee75c101278e0234b646fa72221547d63f97fb66ac112a0569acd110"
-dependencies = [
- "anyhow",
- "cfg-if",
- "chrono",
- "enum-iterator",
- "getset",
- "git2",
- "rustc_version",
- "rustversion",
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,4 @@ async-broadcast = "0.3.4"
 resolv-conf = "0.7.0"
 
 [build-dependencies]
-# latest version does not compile with rust v1.57
-vergen = { version = "=6.0.2", default-features = false, features = ["build", "rustc", "git"] }
-anyhow = "1.0"
+chrono = "*"

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,26 @@
-use anyhow::Result;
-use vergen::{vergen, Config};
+use chrono::Utc;
+use std::process::Command;
 
-fn main() -> Result<()> {
+fn main() {
     // Generate the default 'cargo:' instruction output
-    vergen(Config::default())
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // get timestamp
+    let now = Utc::now();
+    println!("cargo:rustc-env=BUILD_TIMESTAMP={}", now.to_rfc3339());
+
+    // get rust target triple from TARGET env
+    println!(
+        "cargo:rustc-env=BUILD_TARGET={}",
+        std::env::var("TARGET").unwrap()
+    );
+
+    // get git commit
+    let command = Command::new("git").args(&["rev-parse", "HEAD"]).output();
+    let commit = match command {
+        Ok(output) => String::from_utf8(output.stdout).unwrap(),
+        // if error, e.g. build from source with git repo, just show empty string
+        Err(_) => "".to_string(),
+    };
+    println!("cargo:rustc-env=GIT_COMMIT={}", commit);
 }

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -32,10 +32,10 @@ impl fmt::Display for Info {
 impl Version {
     pub fn exec(&self) -> Result<(), Error> {
         let info = Info {
-            version: env!("VERGEN_BUILD_SEMVER"),
-            commit: env!("VERGEN_GIT_SHA"),
-            build_time: env!("VERGEN_BUILD_TIMESTAMP"),
-            target: env!("VERGEN_RUSTC_HOST_TRIPLE"),
+            version: env!("CARGO_PKG_VERSION"),
+            commit: env!("GIT_COMMIT"),
+            build_time: env!("BUILD_TIMESTAMP"),
+            target: env!("BUILD_TARGET"),
         };
         println!("{}", info);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use log::Level;
 use syslog::{BasicLogger, Facility, Formatter3164};
 
 #[derive(Parser, Debug)]
-#[clap(version = env!("VERGEN_BUILD_SEMVER"))]
+#[clap(version = env!("CARGO_PKG_VERSION"))]
 struct Opts {
     /// Path to configuration directory
     #[clap(short, long)]


### PR DESCRIPTION
Backport commit e824402c85d7.

We only need the version, build time, rust target triple, and git commit
for the version command. These values can easily be generated with little
code so we do not need an extra dependency for this.

The main reason for this change is that vergen will fail if no git
commit is found. On distro build systems this is often the case since
they build from a source tar without the git repo. Instead of erroring
we should just show an empty commit in the version output.
