### PR TITLE
Cirrus: Use fixed netavark branch for CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,7 +15,7 @@ env:
     # Rust compiler output lives here (see Makefile)
     CARGO_TARGET_DIR: "$CIRRUS_WORKING_DIR/targets"
     # Testing depends on the latest netavark binary from upstream CI
-    NETAVARK_BRANCH: "main"
+    NETAVARK_BRANCH: "v1.0.1-rhel"
     NETAVARK_URL: "https://api.cirrus-ci.com/v1/artifact/github/containers/netavark/success/binary.zip?branch=${NETAVARK_BRANCH}"
     # Save a little typing (path relative to $CIRRUS_WORKING_DIR)
     SCRIPT_BASE: "./contrib/cirrus"


### PR DESCRIPTION
This is important for the stability of CI in case of a future backport
that happens to be incompatible with netavark `main`.  Since CI
doesn't run very often on the aardvark-dns `v1.0.1-rhel` branch, an
incompatible change may not be noticed.  Fix this by switching off
of the `main` branch onto a netavark release branch.

Signed-off-by: Chris Evich <cevich@redhat.com>