### PR TITLE
lookup: make name lookup case insensitive as per `RFC4343`

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -58,7 +58,9 @@ impl DNSBackend {
     // TODO: right now this returns v4 and v6 addresses intermixed and relies on
     // the caller to sort through them; we could add a v6 bool as an argument
     // and do it here instead.
-    pub fn lookup(&self, requester: &IpAddr, mut name: &str) -> DNSResult {
+    pub fn lookup(&self, requester: &IpAddr, entry: &str) -> DNSResult {
+        // Normalize lookup entry to lowercase.
+        let mut name = entry.to_lowercase();
         let nets = match self.ip_mappings.get(requester) {
             Some(n) => n,
             None => return DNSResult::NoSuchIP,
@@ -78,11 +80,11 @@ impl DNSBackend {
             if !name.is_empty() {
                 if let Some(lastchar) = name.chars().last() {
                     if lastchar == '.' {
-                        name = &name[0..name.len() - 1];
+                        name = (&name[0..name.len() - 1]).to_string();
                     }
                 }
             }
-            if let Some(addrs) = net_names.get(name) {
+            if let Some(addrs) = net_names.get(&name) {
                 results.append(&mut addrs.clone());
             }
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -270,7 +270,7 @@ fn parse_config(path: &std::path::Path) -> Result<(Vec<IpAddr>, Vec<CtrEntry>), 
         }
         let aliases: Vec<String> = parts[3]
             .split(',')
-            .map(|x| x.to_string())
+            .map(|x| x.to_string().to_lowercase())
             .collect::<Vec<String>>();
 
         if aliases.is_empty() {
@@ -285,7 +285,7 @@ fn parse_config(path: &std::path::Path) -> Result<(Vec<IpAddr>, Vec<CtrEntry>), 
         }
 
         ctrs.push(CtrEntry {
-            id: parts[0].to_string(),
+            id: parts[0].to_string().to_lowercase(),
             v4: v4_addr,
             v6: v6_addr,
             aliases,

--- a/src/test/config/podman/podman
+++ b/src/test/config/podman/podman
@@ -1,4 +1,5 @@
 10.88.0.1
 68fb291b0318b54a71f6f3636e58bd0896f084e5ba4fa311ecf36e019c5e6e43 10.88.0.2  condescendingnash
+68fb291b0318b54a71f6f3636e58bd0896f084e5ba4fa311ecf36e019c5e6e48 10.88.0.5  HelloWorld
 95655fb6832ba134efa66e9c80862a6c9b04f3cc6abf8adfdda8c38112c2c6fa 10.88.0.3  hopefulmontalcini,testdbctr
 8bcc5fe0cb09bee5dfb71d61503a87688cfc82aa5f130bcedb19357a17765926 10.88.0.4  trustingzhukovsky,ctr1,ctra

--- a/src/test/test.rs
+++ b/src/test/test.rs
@@ -63,6 +63,48 @@ mod tests {
     }
     #[test]
     // Check lookup query from backend and simulate
+    // case-insensitive dns request from same container
+    // to itself but aardvark must return one ip address i.e v4.
+    // Request address must be v4.
+    // Same container --> (resolve) Same container name --> (on) Same Network
+    fn test_lookup_queries_from_backend_simulate_same_container_request_from_v4_on_v4_entries_case_insensitive(
+    ) {
+        match config::parse_configs("src/test/config/podman") {
+            Ok((backend, _, _)) => {
+                match backend.lookup(&"10.88.0.2".parse().unwrap(), "helloworld") {
+                    DNSResult::Success(ip_vec) => {
+                        assert_eq!(ip_vec.len(), 1);
+                        assert_eq!("10.88.0.5".parse(), Ok(ip_vec[0]));
+                    }
+                    _ => panic!("unexpected dns result"),
+                }
+            }
+            Err(e) => panic!("{}", e),
+        }
+    }
+    #[test]
+    // Check lookup query from backend and simulate
+    // case-insensitive dns request from same container
+    // to itself but aardvark must return one ip address i.e v4.
+    // Request address must be v4.
+    // Same container --> (resolve) Same container name --> (on) Same Network
+    fn test_lookup_queries_from_backend_simulate_same_container_request_from_v4_on_v4_entries_case_insensitive_uppercase(
+    ) {
+        match config::parse_configs("src/test/config/podman") {
+            Ok((backend, _, _)) => {
+                match backend.lookup(&"10.88.0.2".parse().unwrap(), "HELLOWORLD") {
+                    DNSResult::Success(ip_vec) => {
+                        assert_eq!(ip_vec.len(), 1);
+                        assert_eq!("10.88.0.5".parse(), Ok(ip_vec[0]));
+                    }
+                    _ => panic!("unexpected dns result"),
+                }
+            }
+            Err(e) => panic!("{}", e),
+        }
+    }
+    #[test]
+    // Check lookup query from backend and simulate
     // nx_domain on bad lookup queries.
     fn test_lookup_queries_from_backend_simulate_nx_domain() {
         match config::parse_configs("src/test/config/podman") {


### PR DESCRIPTION
As per https://datatracker.ietf.org/doc/html/rfc4343 DNS name resolution
must be case insensitive so convert everything to lowercase by
performing a lookup and storing names into the backend.

Closes: https://github.com/containers/podman/issues/14525