### PR TITLE
main: run aardvark as a `daemon` via `forking` and maintain its partial `daemon` like nature.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,9 @@ dependencies = [
  "chrono",
  "clap",
  "futures-util",
+ "libc",
  "log",
+ "nix",
  "resolv-conf",
  "signal-hook",
  "syslog",
@@ -87,6 +89,12 @@ name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cfg-if"
@@ -430,6 +438,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +465,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
  "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ signal-hook = "0.3.13"
 tokio = { version = "1.19.2", features = ["tokio-macros", "full"] }
 async-broadcast = "0.4.0"
 resolv-conf = "0.7.0"
+nix = "0.23.0"
+libc = "0.2"
 
 [build-dependencies]
 chrono = "0.4.7"

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,8 +1,14 @@
 //! Runs the aardvark dns server with provided config
 use crate::server::serve;
 use clap::Parser;
-use log::debug;
+use nix::unistd;
+use nix::unistd::{dup2, fork, ForkResult};
+use std::fs::File;
+use std::fs::OpenOptions;
 use std::io::Error;
+use std::io::Write;
+use std::os::unix::io::AsRawFd;
+use std::os::unix::io::FromRawFd;
 
 #[derive(Parser, Debug)]
 pub struct Run {}
@@ -19,18 +25,64 @@ impl Run {
         port: u32,
         filter_search_domain: String,
     ) -> Result<(), Error> {
-        debug!(
-            "Setting up aardvark server with input directory as {:?}",
-            input_dir
-        );
+        // create a temporary path for unix socket
+        // so parent can communicate with child and
+        // only exit when child is ready to serve.
+        let (ready_pipe_read, ready_pipe_write) = nix::unistd::pipe()?;
 
-        if let Err(er) = serve::serve(&input_dir, port, &filter_search_domain) {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("Error starting server {}", er),
-            ));
+        // fork and verify if server is running
+        // and exit parent
+        // setsid() ensures that there is no controlling terminal on the child process
+        match unsafe { fork() } {
+            Ok(ForkResult::Parent { child, .. }) => {
+                log::debug!("starting aardvark on a child with pid {}", child);
+                // verify aardvark here and block till will start
+                unistd::read(ready_pipe_read, &mut [0_u8; 1])?;
+                unistd::close(ready_pipe_read)?;
+                unistd::close(ready_pipe_write)?;
+                Ok(())
+            }
+            Ok(ForkResult::Child) => {
+                // remove any controlling terminals
+                // but don't hardstop if this fails
+                let _ = unsafe { libc::setsid() }; // check https://docs.rs/libc
+                                                   // close fds -> stdout, stdin and stderr
+                let dev_null = OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open("/dev/null")
+                    .map_err(|e| std::io::Error::new(e.kind(), format!("/dev/null: {}", e)));
+                // redirect stdout, stdin and stderr to /dev/null
+                if let Ok(dev_null) = dev_null {
+                    let fd = dev_null.as_raw_fd();
+                    let _ = dup2(fd, 0);
+                    let _ = dup2(fd, 1);
+                    let _ = dup2(fd, 2);
+                    if fd < 2 {
+                        std::mem::forget(dev_null);
+                    }
+                }
+
+                let mut f = unsafe { File::from_raw_fd(ready_pipe_write) };
+                write!(&mut f, "ready")?;
+                unistd::close(ready_pipe_read)?;
+                unistd::close(ready_pipe_write)?;
+                if let Err(er) = serve::serve(&input_dir, port, &filter_search_domain) {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        format!("Error starting server {}", er),
+                    ));
+                }
+                Ok(())
+            }
+            Err(err) => {
+                log::debug!("fork failed with error {}", err);
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("fork failed with error: {}", err),
+                ));
+            }
         }
-        Ok(())
     }
 }
 


### PR DESCRIPTION
This is one the redesign PR for aardvark-dns and netavark. Design
proposes that `forking` will happen at aardvark-end instead of
netavark and aarvark verifies validity of server before returning
control to aardvark.

Redesign proposal

* Aardvark will invoke server on the child process by double-forking.
* Parent waits for child to show up  and verify against a dummy DNS
  query to check if server is running.
* Exit parent on success and deatch child.

* Calling process will wait for aardvark's parent process to return.
* On successful return from parent it will be assumed that aardvark is
  running properly

One new design is implemented and merged and netavark starts using this
it should close

* https://github.com/containers/podman/issues/14173
* https://github.com/containers/podman/issues/14171