### PR TITLE
CoPR: Fix build for CentOS 8 Stream

### DIFF
--- a/aardvark-dns.spec.rpkg
+++ b/aardvark-dns.spec.rpkg
@@ -45,9 +45,6 @@ BuildRequires: git-core
 BuildRequires: make
 
 ExclusiveArch:  %{rust_arches}
-%if %{__cargo_skip_build}
-BuildArch:      noarch
-%endif
 
 %global _description %{expand:
 %{summary}}


### PR DESCRIPTION
Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

@flouthoc @mheon @baude @Luap99 @rhatdan PTAL

If you have admin/commit access to the `rhcontainerbot/podman-next` copr, this can be tested using: `rpkg copr-build rhcontainerbot/podman-next` . Either way, this change provides successful c8s build, results at: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/build/4537990/ 