### PR TITLE
Move instead of borrow to avoid need to clone

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -38,17 +38,15 @@ pub enum DNSResult {
 
 impl DNSBackend {
     // Create a new backend from the given set of network mappings.
-    // TODO: If we want to optimize even more strongly, we can probably avoid
-    // the clone() calls here.
     pub fn new(
-        containers: &HashMap<IpAddr, Vec<String>>,
-        networks: &HashMap<String, HashMap<String, Vec<IpAddr>>>,
-        reverse: &HashMap<String, HashMap<IpAddr, Vec<String>>>,
+        containers: HashMap<IpAddr, Vec<String>>,
+        networks: HashMap<String, HashMap<String, Vec<IpAddr>>>,
+        reverse: HashMap<String, HashMap<IpAddr, Vec<String>>>,
     ) -> DNSBackend {
         DNSBackend {
-            ip_mappings: containers.clone(),
-            name_mappings: networks.clone(),
-            reverse_mappings: reverse.clone(),
+            ip_mappings: containers,
+            name_mappings: networks,
+            reverse_mappings: reverse,
         }
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -169,7 +169,7 @@ pub fn parse_configs(
     }
 
     Ok((
-        DNSBackend::new(&ctrs, &network_names, &reverse),
+        DNSBackend::new(ctrs, network_names, reverse),
         listen_ips_4,
         listen_ips_6,
     ))


### PR DESCRIPTION
This gets rids of a small TODO issue, and avoids copying three potentially large HashMaps.