### PR TITLE
cargo.toml: lock build-deps for publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ async-broadcast = "0.4.0"
 resolv-conf = "0.7.0"
 
 [build-dependencies]
-chrono = "*"
+chrono = "0.4.7"


### PR DESCRIPTION
Need to lock build deps for publishing.