### PR TITLE
Makefile: add target for release tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,14 @@ vendor-rm-windows:
 		rm -fr vendor/winapi*gnu*/lib/*.a; \
 	fi
 
+.PHONY: vendor-tarball
+vendor-tarball: build vendor
+	VERSION=$(shell bin/aardvark-dns --version | cut -f2 -d" ") && \
+	[[ $$VERSION == *-dev ]] && echo "version ends with -dev" && exit 1; \
+	tar cvf aardvark-dns-$$VERSION-vendor.tar.gz vendor/ && \
+	gzip -c bin/aardvark-dns > aardvark-dns.gz && \
+	sha256sum aardvark-dns.gz aardvark-dns-$$VERSION-vendor.tar.gz > sha256sum
+	rm -rf vendor/
 
 .PHONY: help
 help:


### PR DESCRIPTION
Add a target to automatically create the vendor tarball and the extra
files. This can only be used on a version which has not the -dev suffix
to prevent user errors.
