### PR TITLE
GHA: Add Cirrus-cron failure notifications

### DIFF
--- a/.github/workflows/check_cirrus_cron.yml
+++ b/.github/workflows/check_cirrus_cron.yml
@@ -1,0 +1,17 @@
+---
+
+on:
+  # Note: This only applies to the default branch.
+  schedule:
+    # N/B: This should correspond to a period slightly after
+    # the last job finishes running.  See job defs. at:
+    # https://cirrus-ci.com/settings/repository/5268168076689408
+    - cron:  '59 23 * * 1-5'
+  # Debug: Allow triggering job manually in github-actions WebUI
+  workflow_dispatch: {}
+
+jobs:
+  # Ref: https://docs.github.com/en/actions/using-workflows/reusing-workflows
+  call_cron_failures:
+    uses: containers/buildah/.github/workflows/check_cirrus_cron.yml@main
+    secrets: inherit


### PR DESCRIPTION
This re-uses the buildah-workflow to send e-mail to podman-monitor if
any Cirrus-cron job failed, or the workflow itself fails.  Necessary to
ensure the CI VM image timestamps are kept updated to prevent pruning.

Signed-off-by: Chris Evich <cevich@redhat.com>