### PR TITLE
Cirrus: Verify expected binary artifacts present

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -79,10 +79,12 @@ build_aarch64_task:
   # However, we don't want to confuse architectures.
   art_prep_script:
     - cd bin
-    - ln aardvark-dns aardvark-dns.$(uname -m)-unknown-linux-gnu
-    - ln aardvark-dns.debug aardvark-dns.debug.$(uname -m)-unknown-linux-gnu
+    - ls -la
+    - mv aardvark-dns aardvark-dns.$(uname -m)-unknown-linux-gnu
+    - mv aardvark-dns.debug aardvark-dns.debug.$(uname -m)-unknown-linux-gnu
+    - mv aardvark-dns.info aardvark-dns.info.$(uname -m)-unknown-linux-gnu
   armbinary_artifacts:  # See success_task
-    path: ./bin/aardvark-dns*-unknown-linux-gnu
+    path: ./bin/aardvark-dns*
 
 
 validate_task:
@@ -264,6 +266,14 @@ success_task:
     - "centos9_build"
   env:
     API_URL_BASE: "https://api.cirrus-ci.com/v1/artifact/build/${CIRRUS_BUILD_ID}"
+    # FAIL task if all expected binary flavors are not present
+    EXP_BINS: >-
+        aardvark-dns
+        aardvark-dns.debug
+        aardvark-dns.info
+        aardvark-dns.aarch64-unknown-linux-gnu
+        aardvark-dns.debug.aarch64-unknown-linux-gnu
+        aardvark-dns.info.aarch64-unknown-linux-gnu
   bin_cache: *ro_bin_cache
   clone_script: *noop
   # The paths used for uploaded artifacts are relative here and in Cirrus
@@ -273,6 +283,10 @@ success_task:
     - unzip /tmp/armbinary.zip
     - mv bin/* ./
     - rm -rf bin
+  artifacts_test_script:  # Other CI systems depend on all files being present
+    - ls -la
+    # If there's a missing file, show what it was in the output
+    - for fn in $EXP_BINS; do [[ -r "$(echo $fn|tee /dev/stderr)" ]] || exit 1; done
   # Upload tested binary for consumption downstream
   # https://cirrus-ci.org/guide/writing-tasks/#artifacts-instruction
   binary_artifacts:

--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -25,7 +25,7 @@ _run_build() {
 
     # This will get scooped up and become part of the artifact archive.
     # Identify where the binary came from to benefit downstream consumers.
-        cat >> bin/aardvark-dns.info << EOF
+        cat | tee bin/aardvark-dns.info << EOF
 repo: $CIRRUS_REPO_CLONE_URL
 branch: $CIRRUS_BASE_BRANCH
 title: $CIRRUS_CHANGE_TITLE


### PR DESCRIPTION
Other CI systems depend/expect a full set of compiled binaries are
included in the success task's binary artifact (zip file).  However,
it's possible some mistake in CI could silently lead to one or more
binaries not being produced.  For example, a `bin_cache` failure.  Fix
this by verifying all expected/required files are present.  If not,
print the name of the missing binary to assist in
troubleshooting/debugging.

Signed-off-by: Chris Evich <cevich@redhat.com>