### PR TITLE
[v1.0.1-rhel] tests: fix slirp flake v2

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -296,8 +296,8 @@ function create_netns() {
 
     # we have to wait for unshare and check that we have a new ns before returning
     local timeout=2
-    while [[ $timeout -gt 1 ]]; do
-        if [[ "$(ls -l /proc/self/ns/net)" != "$(ls -l /proc/$pid/ns/net)" ]]; then
+    while [[ $timeout -gt 0 ]]; do
+        if [ "$(readlink /proc/self/ns/net)" != "$(readlink /proc/$pid/ns/net)" ]; then
             echo $pid
             return
         fi


### PR DESCRIPTION
Commit 4a451679ebbe points at the correct error source however the fix
for it was not working. ls -l will always look different when called on
different paths. We only want to compare the actual link target. Fix
this by using readlink.

Fixes #177
