### PR TITLE
Bump to v1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aardvark-dns"
-version = "1.0.4-dev"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aardvark-dns"
-version = "1.1.0"
+version = "1.1.1-dev"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aardvark-dns"
-version = "1.0.4-dev"
+version = "1.1.0"
 edition = "2018"
 authors = ["github.com/containers"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aardvark-dns"
-version = "1.1.0"
+version = "1.1.1-dev"
 edition = "2018"
 authors = ["github.com/containers"]
 license = "Apache-2.0"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,13 @@
 # Release Notes
 
+## v1.1.0
+* Changed Aardvark to fork on startup to daemonize, as opposed to have this done by callers. This avoids race conditions around startup.
+* Name resolution is now case-insensitive.
+
 ## v1.0.3
 * Updated dependancy libraries
 * Reduction in CPU use
 * Fixed bug with duplicate network names
-
 
 ## v1.0.2
 * Updated dependency libraries


### PR DESCRIPTION
As with Netavark, not on a branch, we can cut one later if required.