### PR TITLE
config: use multiple ips per line

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,5 @@ make
 ```console
 RUST_LOG=trace ./bin/aardvark-dns --config src/test/config/podman/ --port 5533 run
 ```
+
+### [Configuration file format](./config.md)

--- a/config.md
+++ b/config.md
@@ -1,0 +1,26 @@
+# Configuration format
+
+Aardvark-dns will read configuration files from a given directory.
+
+Inside this directory there should be at least one config file. The name of the file equals the network name.
+
+The first line in the config must contain a comma separated list of listening ips for this network, usually the bridge ips.
+At least one ip must be given.
+
+All following lines must contain the dns entries in this format:
+```
+[containerID][space][comma sparated ipv4 list][space][comma separated ipv6 list][space][comma separated dns names]
+```
+
+Aardvark-dns will reload all config files when receiving a SIGHUB signal.
+
+
+## Example
+
+```
+10.0.0.1,fdfd::1
+f35256b5e2f72ec8cb7d974d4f8841686fc8921fdfbc867285b50164e313f715 10.0.0.2 fdfd::2 testmulti1
+e5df0cdbe0136a30cc3e848d495d2cc6dada25b7dedc776b4584ce2cbba6f06f 10.0.0.3 fdfd::3 testmulti2
+```
+
+Also see [./src/test/config/](./src/test/config/) for more config examples

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -201,27 +201,13 @@ fn parse_config(path: &std::path::Path) -> Result<(Vec<IpAddr>, Vec<CtrEntry>), 
             continue;
         }
         if is_first {
-            // First line is comma-separated V4 and V6
-            if line.contains(',') {
-                for ip in line.split(',') {
-                    let local_ip = match ip.parse() {
-                        Ok(l) => l,
-                        Err(e) => {
-                            return Err(std::io::Error::new(
-                                std::io::ErrorKind::Other,
-                                format!("error parsing ip address {}: {}", ip, e),
-                            ))
-                        }
-                    };
-                    bind_addrs.push(local_ip);
-                }
-            } else {
-                let local_ip = match line.parse() {
+            for ip in line.split(',') {
+                let local_ip = match ip.parse() {
                     Ok(l) => l,
                     Err(e) => {
                         return Err(std::io::Error::new(
                             std::io::ErrorKind::Other,
-                            format!("error parsing ip address {}: {}", line, e),
+                            format!("error parsing ip address {}: {}", ip, e),
                         ))
                     }
                 };

--- a/src/test/config/podman_v6_entries/podman_v6_entries_proper
+++ b/src/test/config/podman_v6_entries/podman_v6_entries_proper
@@ -1,0 +1,3 @@
+10.0.0.1,10.0.1.1,fdfd::1,fddd::1
+f35256b5e2f72ec8cb7d974d4f8841686fc8921fdfbc867285b50164e313f715 10.0.0.2,10.0.1.2 fdfd::2,fddd::2 testmulti1
+e5df0cdbe0136a30cc3e848d495d2cc6dada25b7dedc776b4584ce2cbba6f06f 10.0.0.3,10.0.1.3 fdfd::3,fddd::3 testmulti2


### PR DESCRIPTION
We have to support several ipv4 and v6 addresses per container. The
current way of creating the configs in aardvark are just broken IMO. We
should never have to duplicate the container id and aliases just to set
more ips.

This patch is fully backwards compatible and will allow much better
config generation in netavark.