### PR TITLE
[v1.1.0-rhel] makefile: remove windows specific libaries from vendor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,8 @@ vendor: ## vendor everything into vendor/
 vendor-rm-windows:
 	if [ -d "vendor/winapi" ]; then \
 		rm -fr vendor/winapi*gnu*/lib/*.a; \
+		rm -fr vendor/windows*/lib/*.a; \
+		rm -fr vendor/windows*/lib/*.lib; \
 	fi
 
 .PHONY: vendor-tarball


### PR DESCRIPTION
Modify `vendor-rm-windows` to remove windows specific libaries from
vendor directory

Backport of https://github.com/containers/aardvark-dns/pull/201

@lsm5 @mheon @baude @jnovy PTAL

