### PR TITLE
coredns: response message always set recursion available (`RA`) when `RD` is set in request

### DIFF
--- a/src/dns/coredns.rs
+++ b/src/dns/coredns.rs
@@ -340,6 +340,10 @@ fn reply(mut sender: BufStreamHandle, socket_addr: SocketAddr, msg: &Message) ->
     let id = msg.id();
     let mut msg_mut = msg.clone();
     msg_mut.set_message_type(MessageType::Response);
+    // If `RD` is set and `RA` is false set `RA`.
+    if msg.recursion_desired() && !msg.recursion_available() {
+        msg_mut.set_recursion_available(true);
+    }
     let response = SerialMessage::new(msg_mut.to_vec().ok()?, socket_addr);
 
     match sender.send(response) {

--- a/test/100-basic-name-resolution.bats
+++ b/test/100-basic-name-resolution.bats
@@ -17,10 +17,16 @@ load helpers
 	a1_pid=$CONTAINER_NS_PID
 	run_in_container_netns "$a1_pid" "dig" "+short" "aone" "@$gw"
 	assert "$ip_a1"
+	# Set recursion bit is already set if requested so output must not
+	# contain unexpected warning.
+	assert "$output" !~ "WARNING: recursion requested but not available"
 
 	run_in_container_netns "$a1_pid" "dig" "+short" "google.com" "@$gw"
 	# validate that we get an ipv4
 	assert "$output" =~ "[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+"
+	# Set recursion bit is already set if requested so output must not
+	# contain unexpected warning.
+	assert "$output" !~ "WARNING: recursion requested but not available"
 }
 
 @test "basic container - ndots incomplete bad entry must NXDOMAIN instead of forwarding and timing out" {
@@ -49,10 +55,16 @@ load helpers
 	a1_pid=$CONTAINER_NS_PID
 	run_in_container_netns "$a1_pid" "dig" "+short" "aone" "@$gw"
 	assert "$ip_a1"
+	# Set recursion bit is already set if requested so output must not
+	# contain unexpected warning.
+	assert "$output" !~ "WARNING: recursion requested but not available"
 
 	run_in_container_netns "$a1_pid" "dig" "+short" "google.com" "@$gw"
 	# validate that we get an ipv4
 	assert "$output" =~ "[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+"
+	# Set recursion bit is already set if requested so output must not
+	# contain unexpected warning.
+	assert "$output" !~ "WARNING: recursion requested but not available"
 }
 
 @test "basic container - dns itself with long network name" {
@@ -66,6 +78,9 @@ load helpers
 	a1_pid=$CONTAINER_NS_PID
 	run_in_container_netns "$a1_pid" "dig" "+short" "aone" "@$gw"
 	assert "$ip_a1"
+	# Set recursion bit is already set if requested so output must not
+	# contain unexpected warning.
+	assert "$output" !~ "WARNING: recursion requested but not available"
 }
 
 @test "two containers on the same network" {
@@ -88,6 +103,11 @@ load helpers
 	# Resolve container names to IPs
 	dig "$a1_pid" "atwo" "$gw"
 	assert "$a2_ip"
+	# Set recursion bit
+        assert "$output" !~ "WARNING: recursion requested but not available"
 	dig "$a2_pid" "aone" "$gw"
 	assert "$a1_ip"
+	# Set recursion bit is already set if requested so output must not
+	# contain unexpected warning.
+	assert "$output" !~ "WARNING: recursion requested but not available"
 }


### PR DESCRIPTION
Set recursion available in all response message by setting `RA` flag in
response packet.

Closes: https://github.com/containers/aardvark-dns/issues/204