### PR TITLE
Cirrus: Update meta-task for EC2 image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,7 +19,7 @@ env:
     NETAVARK_URL: "https://api.cirrus-ci.com/v1/artifact/github/containers/netavark/success/binary.zip?branch=${NETAVARK_BRANCH}"
     # Save a little typing (path relative to $CIRRUS_WORKING_DIR)
     SCRIPT_BASE: "./contrib/cirrus"
-    IMAGE_SUFFIX: "c4801636756357120"
+    IMAGE_SUFFIX: "c5823947156488192"
     FEDORA_NETAVARK_IMAGE: "fedora-netavark-${IMAGE_SUFFIX}"
 
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,6 +22,7 @@ env:
     IMAGE_SUFFIX: "c5823947156488192"
     FEDORA_NETAVARK_IMAGE: "fedora-netavark-${IMAGE_SUFFIX}"
     FEDORA_NETAVARK_AMI: "fedora-netavark-aws-arm64-${IMAGE_SUFFIX}"
+    EC2_INST_TYPE: "t4g.xlarge"
 
 
 gcp_credentials: ENCRYPTED[f6a0e4101418bec8180783b208721fc990772817364fed0346f5fd126bf0cfca03738dd8c7fb867944637a1eac7cec37]
@@ -61,7 +62,7 @@ build_aarch64_task:
   # Compiling is very CPU intensive, make it chooch quicker for this task only
   ec2_instance: &standard_build_ec2_aarch64
     image: "$FEDORA_NETAVARK_AMI"
-    type: t4g.xlarge
+    type: $EC2_INST_TYPE
     region: us-east-1
     architecture: arm64  # CAUTION: This has to be "arm64", not aarch64.
   cargo_cache: &cargo_cache_aarch64

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,6 +21,7 @@ env:
     SCRIPT_BASE: "./contrib/cirrus"
     IMAGE_SUFFIX: "c5823947156488192"
     FEDORA_NETAVARK_IMAGE: "fedora-netavark-${IMAGE_SUFFIX}"
+    FEDORA_NETAVARK_AMI: "fedora-netavark-aws-arm64-${IMAGE_SUFFIX}"
 
 
 gcp_credentials: ENCRYPTED[f6a0e4101418bec8180783b208721fc990772817364fed0346f5fd126bf0cfca03738dd8c7fb867944637a1eac7cec37]
@@ -59,7 +60,7 @@ build_aarch64_task:
   alias: "build_aarch64"
   # Compiling is very CPU intensive, make it chooch quicker for this task only
   ec2_instance: &standard_build_ec2_aarch64
-    image: ami-0f89dfa699fe590b0
+    image: "$FEDORA_NETAVARK_AMI"
     type: t4g.xlarge
     region: us-east-1
     architecture: arm64  # CAUTION: This has to be "arm64", not aarch64.
@@ -213,8 +214,10 @@ meta_task:
     env:
         # Space-separated list of images used by this repository state
         IMGNAMES: "${FEDORA_NETAVARK_IMAGE}"
+        EC2IMGNAMES: "$FEDORA_NETAVARK_AMI"
         BUILDID: "${CIRRUS_BUILD_ID}"
         REPOREF: "${CIRRUS_REPO_NAME}"
+        AWSINI: ENCRYPTED[94661de0a481bfa6757f6ef26f896c28578c764f00364a293871b7576337c947304e2dfa35e3819c066057ef3957237f]
         GCPJSON: ENCRYPTED[4c8f37db84c8afb3d67932ebbf1f062e5e7e54b64e9f99624d96d828d2b8677624fb1470a9b12c097e06afeb11fb8c4e]
         GCPNAME: ENCRYPTED[1d96b7a11a12abe142a2e6f5a97ff6cca2bdcbe73724d560d9a2d339b7323b911c814d814057e19932f9d339e9a4c929]
         GCPPROJECT: libpod-218412


### PR DESCRIPTION
Also, switch to referencing the EC2 AMI by name-tag instead of ID.