### PR TITLE
clippy: remove needless returns from code.

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -77,10 +77,10 @@ impl Run {
             }
             Err(err) => {
                 log::debug!("fork failed with error {}", err);
-                return Err(std::io::Error::new(
+                Err(std::io::Error::new(
                     std::io::ErrorKind::Other,
                     format!("fork failed with error: {}", err),
-                ));
+                ))
             }
         }
     }

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -194,12 +194,10 @@ fn core_serve_loop(
 
             Ok(())
         }
-        Err(e) => {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("unable to parse config: {}", e),
-            ))
-        }
+        Err(e) => Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("unable to parse config: {}", e),
+        )),
     }
 }
 
@@ -229,19 +227,15 @@ async fn start_dns_server(
     {
         Ok(mut server) => match server.run().await {
             Ok(_) => Ok(()),
-            Err(e) => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("unable to start CoreDns server: {}", e),
-                ))
-            }
-        },
-        Err(e) => {
-            return Err(std::io::Error::new(
+            Err(e) => Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
-                format!("unable to create CoreDns server: {}", e),
-            ))
-        }
+                format!("unable to start CoreDns server: {}", e),
+            )),
+        },
+        Err(e) => Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("unable to create CoreDns server: {}", e),
+        )),
     }
 }
 


### PR DESCRIPTION
New rule blocks CI since `validation` against clippy is failing hence
remove needless returns from serve and run.

See: https://rust-lang.github.io/rust-clippy/master/index.html#needless_return

