### PR TITLE
[CI:BUILD] Packit: initial enablement

### DIFF
--- a/.packit.sh
+++ b/.packit.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# This script handles any custom processing of the spec file generated using the `post-upstream-clone`
+# action and gets used by the fix-spec-file action in .packit.yaml.
+
+set -eo pipefail
+
+# Get Version from HEAD
+VERSION=$(grep '^version' Cargo.toml | cut -d\" -f2 | sed -e 's/-/~/')
+
+# Generate source tarball
+git archive --prefix=aardvark-dns-$VERSION/ -o aardvark-dns-$VERSION.tar.gz HEAD
+
+# RPM Spec modifications
+
+# Fix Version
+sed -i "s/^Version:.*/Version: $VERSION/" aardvark-dns.spec
+
+# Fix Release
+sed -i "s/^Release:.*/Release: $PACKIT_RPMSPEC_RELEASE%{?dist}/" aardvark-dns.spec
+
+# Fix Source0
+sed -i "s/^Source:.*.tar.gz/Source: aardvark-dns-$VERSION.tar.gz/" aardvark-dns.spec
+
+# Fix autosetup
+sed -i "s/^%autosetup.*/%autosetup -Sgit -n %{name}-$VERSION/" aardvark-dns.spec

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,25 @@
+---
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+# Build targets can be found at:
+# https://copr.fedorainfracloud.org/coprs/rhcontainerbot/packit-builds/
+
+specfile_path: aardvark-dns.spec
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    owner: rhcontainerbot
+    project: packit-builds
+    enable_net: true
+    srpm_build_deps:
+      - cargo
+      - make
+      - openssl-devel
+      - rpkg
+    actions:
+      post-upstream-clone:
+        - "rpkg spec --outdir ./"
+      fix-spec-file:
+        - "bash .packit.sh"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "aardvark-dns"
+# This version specification is reused by .packit.sh to generate rpm version
 version = "1.6.0-dev"
 edition = "2018"
 authors = ["github.com/containers"]


### PR DESCRIPTION
This commit will run Koji scratch builds on every PR against all active
releases of Fedora, thus allowing buildability checks before the
PR merges.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>