### PR TITLE
Make build date reproducible

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
-use chrono::Utc;
+use chrono::{DateTime, NaiveDateTime, Utc};
+use std::env;
 use std::process::Command;
 
 fn main() {
@@ -6,7 +7,14 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
     // get timestamp
-    let now = Utc::now();
+    let now = match env::var("SOURCE_DATE_EPOCH") {
+        Ok(val) => {
+            let naive = NaiveDateTime::from_timestamp(val.parse::<i64>().unwrap(), 0);
+            let datetime: DateTime<Utc> = DateTime::from_utc(naive, Utc);
+            datetime
+        }
+        Err(_) => Utc::now(),
+    };
     println!("cargo:rustc-env=BUILD_TIMESTAMP={}", now.to_rfc3339());
 
     // get rust target triple from TARGET env


### PR DESCRIPTION
To make aardvark-dns bit by bit reproducible the embedded build date needs to adhere to the SOURCE_DATE_EPOCH standard. So a rebuilder can set SOURCE_DATE_EPOCH to the build binary's build date and reproduce the binary succesfully.

https://reproducible-builds.org/docs/source-date-epoch/

Signed-off-by: Jelle van der Waa <jelle@archlinux.org>

---

Our reproducible test output before this change: https://reproducible.archlinux.org/api/v0/builds/343291/diffoscope