### PR TITLE
Release1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aardvark-dns"
-version = "1.2.0"
+version = "1.2.0-dev"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aardvark-dns"
-version = "1.1.1-dev"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aardvark-dns"
-version = "1.1.1-dev"
+version = "1.2.0"
 edition = "2018"
 authors = ["github.com/containers"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aardvark-dns"
-version = "1.2.0"
+version = "1.2.0-dev"
 edition = "2018"
 authors = ["github.com/containers"]
 license = "Apache-2.0"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## v1.2.0
+* coredns: do not combine results of A and AAAA records
+* run,serve: create aardvark pid in child before we notify parent process
+* coredns: response message set recursion available if RD is true
+* document configuration format
+
 ## v1.1.0
 * Changed Aardvark to fork on startup to daemonize, as opposed to have this done by callers. This avoids race conditions around startup.
 * Name resolution is now case-insensitive.


### PR DESCRIPTION
* coredns: do not combine results of A and AAAA records
* run,serve: create aardvark pid in child before we notify parent process
* coredns: response message set recursion available if RD is true
* document configuration format