### PR TITLE
Cirrus: CI branch updates

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@
 # Main collection of env. vars to set for all tasks and scripts.
 env:
     # Actual|intended branch for this run
-    DEST_BRANCH: "main"
+    DEST_BRANCH: "v1.1.0-rhel"
     # The default is 'sh' if unspecified
     CIRRUS_SHELL: "/bin/bash"
     # Location where source repo. will be cloned
@@ -15,7 +15,7 @@ env:
     # Rust compiler output lives here (see Makefile)
     CARGO_TARGET_DIR: "$CIRRUS_WORKING_DIR/targets"
     # Testing depends on the latest netavark binary from upstream CI
-    NETAVARK_BRANCH: "main"
+    NETAVARK_BRANCH: "v1.1.0-rhel"
     NETAVARK_URL: "https://api.cirrus-ci.com/v1/artifact/github/containers/netavark/success/binary.zip?branch=${NETAVARK_BRANCH}"
     # Save a little typing (path relative to $CIRRUS_WORKING_DIR)
     SCRIPT_BASE: "./contrib/cirrus"

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,6 @@ mock-rpm:
 .PHONY: validate
 validate: $(CARGO_TARGET_DIR)
 	cargo fmt --all -- --check
-	cargo clippy -p aardvark-dns -- -D warnings
 
 .PHONY: vendor
 vendor: ## vendor everything into vendor/


### PR DESCRIPTION
This Depends on https://github.com/containers/netavark/pull/423 merging and [a branch-build running and passing](https://cirrus-ci.com/github/containers/netavark/v1.1.0-rhel).