### PR TITLE
aardvark-dns: add support for container's custom `dns_servers`

### DIFF
--- a/config.md
+++ b/config.md
@@ -9,7 +9,7 @@ At least one ip must be given.
 
 All following lines must contain the dns entries in this format:
 ```
-[containerID][space][comma sparated ipv4 list][space][comma separated ipv6 list][space][comma separated dns names]
+[containerID][space][comma sparated ipv4 list][space][comma separated ipv6 list][space][comma separated dns names][(optional)[space][comma seperated DNS servers]]
 ```
 
 Aardvark-dns will reload all config files when receiving a SIGHUB signal.
@@ -19,7 +19,7 @@ Aardvark-dns will reload all config files when receiving a SIGHUB signal.
 
 ```
 10.0.0.1,fdfd::1
-f35256b5e2f72ec8cb7d974d4f8841686fc8921fdfbc867285b50164e313f715 10.0.0.2 fdfd::2 testmulti1
+f35256b5e2f72ec8cb7d974d4f8841686fc8921fdfbc867285b50164e313f715 10.0.0.2 fdfd::2 testmulti1 8.8.8.8,1.1.1.1
 e5df0cdbe0136a30cc3e848d495d2cc6dada25b7dedc776b4584ce2cbba6f06f 10.0.0.3 fdfd::3 testmulti2
 ```
 

--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -30,6 +30,8 @@ if [[ $(uname -m) != "x86_64" ]]; then
     mv netavark.$(uname -m)-unknown-linux-gnu netavark
 fi
 chmod a+x /usr/libexec/podman/netavark
+# show netavark commit in CI logs
+/usr/libexec/podman/netavark version
 
 # Warning, this isn't the end.  An exit-handler is installed to finalize
 # setup of env. vars.  This is required for runner.sh to operate properly.

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -19,8 +19,7 @@ pub struct DNSBackend {
     pub reverse_mappings: HashMap<String, HashMap<IpAddr, Vec<String>>>,
     // Map of IP address to DNS server IPs to service queries not handled
     // directly.
-    // Not implemented in initial version, we will always use host resolvers.
-    //ctr_dns: HashMap<IpAddr, Vec<IpAddr>>,
+    pub ctr_dns_server: HashMap<IpAddr, Option<Vec<IpAddr>>>,
 }
 
 pub enum DNSResult {
@@ -42,11 +41,13 @@ impl DNSBackend {
         containers: HashMap<IpAddr, Vec<String>>,
         networks: HashMap<String, HashMap<String, Vec<IpAddr>>>,
         reverse: HashMap<String, HashMap<IpAddr, Vec<String>>>,
+        ctr_dns_server: HashMap<IpAddr, Option<Vec<IpAddr>>>,
     ) -> DNSBackend {
         DNSBackend {
             ip_mappings: containers,
             name_mappings: networks,
             reverse_mappings: reverse,
+            ctr_dns_server,
         }
     }
 

--- a/src/test/config/podman_custom_dns_servers/podman
+++ b/src/test/config/podman_custom_dns_servers/podman
@@ -1,0 +1,5 @@
+10.88.0.1
+68fb291b0318b54a71f6f3636e58bd0896f084e5ba4fa311ecf36e019c5e6e43 10.88.0.2  condescendingnash 8.8.8.8
+68fb291b0318b54a71f6f3636e58bd0896f084e5ba4fa311ecf36e019c5e6e48 10.88.0.5  HelloWorld 3.3.3.3,1.1.1.1,::1
+95655fb6832ba134efa66e9c80862a6c9b04f3cc6abf8adfdda8c38112c2c6fa 10.88.0.3  hopefulmontalcini,testdbctr
+8bcc5fe0cb09bee5dfb71d61503a87688cfc82aa5f130bcedb19357a17765926 10.88.0.4  trustingzhukovsky,ctr1,ctra

--- a/test/100-basic-name-resolution.bats
+++ b/test/100-basic-name-resolution.bats
@@ -12,7 +12,7 @@ load helpers
 	setup_slirp4netns
 
 	subnet_a=$(random_subnet 5)
-	create_config "podman1" $(random_string 64) "aone" "$subnet_a" "10.10.10.10" "a1" "1a"
+	create_config network_name="podman1" container_id=$(random_string 64) container_name="aone" subnet="$subnet_a" custom_dns_server='"10.10.10.10"' aliases='"a1", "1a"'
 	config_a1=$config
 	ip_a1=$(echo "$config_a1" | jq -r .networks.podman1.static_ips[0])
 	gw=$(echo "$config_a1" | jq -r .network_info.podman1.subnets[0].gateway)
@@ -34,7 +34,8 @@ load helpers
 	setup_slirp4netns
 
 	subnet_a=$(random_subnet 5)
-	create_config "podman1" $(random_string 64) "aone" "$subnet_a" "8.8.8.8" "a1" "1a"
+	create_config network_name="podman1" container_id=$(random_string 64) container_name="aone" subnet="$subnet_a" custom_dns_server='"8.8.8.8","1.1.1.1"' aliases='"a1", "1a"'
+
 	config_a1=$config
 	ip_a1=$(echo "$config_a1" | jq -r .networks.podman1.static_ips[0])
 	gw=$(echo "$config_a1" | jq -r .network_info.podman1.subnets[0].gateway)
@@ -58,7 +59,7 @@ load helpers
 	setup_slirp4netns
 
 	subnet_a=$(random_subnet 5)
-	create_config "podman1" $(random_string 64) "aone" "$subnet_a" "" "a1" "1a"
+	create_config network_name="podman1" container_id=$(random_string 64) container_name="aone" subnet="$subnet_a" aliases='"a1", "1a"'
 	config_a1=$config
 	ip_a1=$(echo "$config_a1" | jq -r .networks.podman1.static_ips[0])
 	gw=$(echo "$config_a1" | jq -r .network_info.podman1.subnets[0].gateway)
@@ -82,7 +83,7 @@ load helpers
 	setup_slirp4netns
 
 	subnet_a=$(random_subnet 5)
-	create_config "podman1" $(random_string 64) "aone" "$subnet_a" "" "a1" "1a"
+	create_config network_name="podman1" container_id=$(random_string 64) container_name="aone" subnet="$subnet_a" aliases='"a1", "1a"'
 	config_a1=$config
 	ip_a1=$(echo "$config_a1" | jq -r .networks.podman1.static_ips[0])
 	gw=$(echo "$config_a1" | jq -r .network_info.podman1.subnets[0].gateway)
@@ -96,7 +97,7 @@ load helpers
 	setup_slirp4netns
 
 	subnet_a=$(random_subnet 6)
-	create_config "podman1" $(random_string 64) "aone" "$subnet_a" "" "a1" "1a"
+	create_config network_name="podman1" container_id=$(random_string 64) container_name="aone" subnet="$subnet_a" aliases='"a1", "1a"'
 	config_a1=$config
 	ip_a1=$(echo "$config_a1" | jq -r .networks.podman1.static_ips[0])
 	gw=$(echo "$config_a1" | jq -r .network_info.podman1.subnets[0].gateway)
@@ -123,7 +124,7 @@ load helpers
 @test "basic container - dns itself with long network name" {
 	subnet_a=$(random_subnet 5)
 	long_name="podman11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
-	create_config "$long_name" $(random_string 64) "aone" "$subnet_a" "" "a1" "1a"
+	create_config network_name="$long_name" container_id=$(random_string 64) container_name="aone" subnet="$subnet_a" aliases='"a1", "1a"'
 	config_a1=$config
 	ip_a1=$(echo "$config_a1" | jq -r .networks.$long_name.static_ips[0])
 	gw=$(echo "$config_a1" | jq -r .network_info.$long_name.subnets[0].gateway)
@@ -139,7 +140,7 @@ load helpers
 @test "two containers on the same network" {
 	# container a1
 	subnet_a=$(random_subnet 5)
-	create_config "podman1" $(random_string 64) "aone" "$subnet_a" "" "a1" "1a"
+	create_config network_name="podman1" container_id=$(random_string 64) container_name="aone" subnet="$subnet_a" aliases='"a1", "1a"'
 	config_a1="$config"
 	a1_ip=$(echo "$config_a1" | jq -r .networks.podman1.static_ips[0])
 	gw=$(echo "$config_a1" | jq -r .network_info.podman1.subnets[0].gateway)
@@ -147,7 +148,7 @@ load helpers
 	a1_pid=$CONTAINER_NS_PID
 
 	# container a2
-	create_config "podman1" $(random_string 64) "atwo" "$subnet_a" "" "a2" "2a"
+	create_config network_name="podman1" container_id=$(random_string 64) container_name="atwo" subnet="$subnet_a" aliases='"a2", "2a"'
 	config_a2="$config"
 	a2_ip=$(echo "$config_a2" | jq -r .networks.podman1.static_ips[0])
 	create_container "$config_a2"

--- a/test/100-basic-name-resolution.bats
+++ b/test/100-basic-name-resolution.bats
@@ -5,11 +5,60 @@
 
 load helpers
 
-@test "basic container - dns itself" {
+# custom DNS server is set to `10.10.10.10` which is invalid DNS server
+# hence all the external request must fail, this test is expected to fail
+# with exit code 124
+@test "basic container - dns itself (custom bad dns server)" {
 	setup_slirp4netns
 
 	subnet_a=$(random_subnet 5)
-	create_config "podman1" $(random_string 64) "aone" "$subnet_a" "a1" "1a"
+	create_config "podman1" $(random_string 64) "aone" "$subnet_a" "10.10.10.10" "a1" "1a"
+	config_a1=$config
+	ip_a1=$(echo "$config_a1" | jq -r .networks.podman1.static_ips[0])
+	gw=$(echo "$config_a1" | jq -r .network_info.podman1.subnets[0].gateway)
+	create_container "$config_a1"
+	a1_pid=$CONTAINER_NS_PID
+	run_in_container_netns "$a1_pid" "dig" "+short" "aone" "@$gw"
+	assert "$ip_a1"
+	# Set recursion bit is already set if requested so output must not
+	# contain unexpected warning.
+	assert "$output" !~ "WARNING: recursion requested but not available"
+
+        # custom dns server is set to 3.3.3.3 which is not a valid DNS server so external DNS request must fail
+	expected_rc=124 run_in_container_netns "$a1_pid" "dig" "+short" "google.com" "@$gw"
+}
+
+# custom DNS server is set to `8.8.8.8, 1.1.1.1` which is valid DNS server
+# hence all the external request must paas.
+@test "basic container - dns itself (custom good dns server)" {
+	setup_slirp4netns
+
+	subnet_a=$(random_subnet 5)
+	create_config "podman1" $(random_string 64) "aone" "$subnet_a" "8.8.8.8" "a1" "1a"
+	config_a1=$config
+	ip_a1=$(echo "$config_a1" | jq -r .networks.podman1.static_ips[0])
+	gw=$(echo "$config_a1" | jq -r .network_info.podman1.subnets[0].gateway)
+	create_container "$config_a1"
+	a1_pid=$CONTAINER_NS_PID
+	run_in_container_netns "$a1_pid" "dig" "+short" "aone" "@$gw"
+	assert "$ip_a1"
+	# Set recursion bit is already set if requested so output must not
+	# contain unexpected warning.
+	assert "$output" !~ "WARNING: recursion requested but not available"
+
+	run_in_container_netns "$a1_pid" "dig" "+short" "google.com" "@$gw"
+	# validate that we get an ipv4
+	assert "$output" =~ "[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+"
+	# Set recursion bit is already set if requested so output must not
+	# contain unexpected warning.
+	assert "$output" !~ "WARNING: recursion requested but not available"
+}
+
+@test "basic container - dns itself custom" {
+	setup_slirp4netns
+
+	subnet_a=$(random_subnet 5)
+	create_config "podman1" $(random_string 64) "aone" "$subnet_a" "" "a1" "1a"
 	config_a1=$config
 	ip_a1=$(echo "$config_a1" | jq -r .networks.podman1.static_ips[0])
 	gw=$(echo "$config_a1" | jq -r .network_info.podman1.subnets[0].gateway)
@@ -33,7 +82,7 @@ load helpers
 	setup_slirp4netns
 
 	subnet_a=$(random_subnet 5)
-	create_config "podman1" $(random_string 64) "aone" "$subnet_a" "a1" "1a"
+	create_config "podman1" $(random_string 64) "aone" "$subnet_a" "" "a1" "1a"
 	config_a1=$config
 	ip_a1=$(echo "$config_a1" | jq -r .networks.podman1.static_ips[0])
 	gw=$(echo "$config_a1" | jq -r .network_info.podman1.subnets[0].gateway)
@@ -47,7 +96,7 @@ load helpers
 	setup_slirp4netns
 
 	subnet_a=$(random_subnet 6)
-	create_config "podman1" $(random_string 64) "aone" "$subnet_a" "a1" "1a"
+	create_config "podman1" $(random_string 64) "aone" "$subnet_a" "" "a1" "1a"
 	config_a1=$config
 	ip_a1=$(echo "$config_a1" | jq -r .networks.podman1.static_ips[0])
 	gw=$(echo "$config_a1" | jq -r .network_info.podman1.subnets[0].gateway)
@@ -74,7 +123,7 @@ load helpers
 @test "basic container - dns itself with long network name" {
 	subnet_a=$(random_subnet 5)
 	long_name="podman11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
-	create_config "$long_name" $(random_string 64) "aone" "$subnet_a" "a1" "1a"
+	create_config "$long_name" $(random_string 64) "aone" "$subnet_a" "" "a1" "1a"
 	config_a1=$config
 	ip_a1=$(echo "$config_a1" | jq -r .networks.$long_name.static_ips[0])
 	gw=$(echo "$config_a1" | jq -r .network_info.$long_name.subnets[0].gateway)
@@ -90,7 +139,7 @@ load helpers
 @test "two containers on the same network" {
 	# container a1
 	subnet_a=$(random_subnet 5)
-	create_config "podman1" $(random_string 64) "aone" "$subnet_a" "a1" "1a"
+	create_config "podman1" $(random_string 64) "aone" "$subnet_a" "" "a1" "1a"
 	config_a1="$config"
 	a1_ip=$(echo "$config_a1" | jq -r .networks.podman1.static_ips[0])
 	gw=$(echo "$config_a1" | jq -r .network_info.podman1.subnets[0].gateway)
@@ -98,7 +147,7 @@ load helpers
 	a1_pid=$CONTAINER_NS_PID
 
 	# container a2
-	create_config "podman1" $(random_string 64) "atwo" "$subnet_a" "a2" "2a"
+	create_config "podman1" $(random_string 64) "atwo" "$subnet_a" "" "a2" "2a"
 	config_a2="$config"
 	a2_ip=$(echo "$config_a2" | jq -r .networks.podman1.static_ips[0])
 	create_container "$config_a2"

--- a/test/200-two-networks.bats
+++ b/test/200-two-networks.bats
@@ -10,7 +10,7 @@ load helpers
 
 	# container a1 on subnet a
 	subnet_a=$(random_subnet 5)
-	create_config "podman1" $(random_string 64) "aone" "$subnet_a"
+	create_config "podman1" $(random_string 64) "aone" "$subnet_a" ""
 	a1_config="$config"
 	a1_ip=$(echo "$a1_config" | jq -r .networks.podman1.static_ips[0])
 	a_gw=$(echo "$a1_config" | jq -r .network_info.podman1.subnets[0].gateway)
@@ -19,7 +19,7 @@ load helpers
 
 	# container b1 on subnet b
 	subnet_b=$(random_subnet 5)
-	create_config "podman2" $(random_string 64) "bone" "$subnet_b"
+	create_config "podman2" $(random_string 64) "bone" "$subnet_b" ""
 	b1_config="$config"
 	b1_ip=$(echo "$b1_config" | jq -r .networks.podman2.static_ips[0])
 	b_gw=$(echo "$b1_config" | jq -r .network_info.podman2.subnets[0].gateway)
@@ -56,7 +56,7 @@ load helpers
 	subnet_b=$(random_subnet 5)
 
 	# A1
-	create_config "podman1" $(random_string 64) "aone" "$subnet_a"
+	create_config "podman1" $(random_string 64) "aone" "$subnet_a" ""
 	a1_config=$config
 	a1_container_id=$(echo "$a1_config" | jq -r .container_id)
 	a1_ip=$(echo "$a1_config" | jq -r .networks.podman1.static_ips[0])
@@ -66,7 +66,7 @@ load helpers
 	a1_pid=$CONTAINER_NS_PID
 
 	# container b1 on subnet b
-	create_config "podman2" $(random_string 64) "bone" "$subnet_b"
+	create_config "podman2" $(random_string 64) "bone" "$subnet_b" ""
 	b1_config=$config
 	b1_ip=$(echo "$b1_config" | jq -r .networks.podman2.static_ips[0])
 	b_gw=$(echo "$b1_config" | jq -r .network_info.podman2.subnets[0].gateway)
@@ -76,7 +76,7 @@ load helpers
 	b_subnets=$(echo $b1_config | jq -r .network_info.podman2.subnets[0])
 
 	# AB2
-	create_config "podman1" $(random_string 64) "abtwo" "$subnet_a"
+	create_config "podman1" $(random_string 64) "abtwo" "$subnet_a" ""
 	a2_config=$config
 	a2_ip=$(echo "$a2_config" | jq -r .networks.podman1.static_ips[0])
 

--- a/test/200-two-networks.bats
+++ b/test/200-two-networks.bats
@@ -10,7 +10,7 @@ load helpers
 
 	# container a1 on subnet a
 	subnet_a=$(random_subnet 5)
-	create_config "podman1" $(random_string 64) "aone" "$subnet_a" ""
+	create_config network_name="podman1" container_id=$(random_string 64) container_name="aone" subnet="$subnet_a"
 	a1_config="$config"
 	a1_ip=$(echo "$a1_config" | jq -r .networks.podman1.static_ips[0])
 	a_gw=$(echo "$a1_config" | jq -r .network_info.podman1.subnets[0].gateway)
@@ -19,7 +19,7 @@ load helpers
 
 	# container b1 on subnet b
 	subnet_b=$(random_subnet 5)
-	create_config "podman2" $(random_string 64) "bone" "$subnet_b" ""
+	create_config network_name="podman2" container_id=$(random_string 64) container_name="bone" subnet="$subnet_b"
 	b1_config="$config"
 	b1_ip=$(echo "$b1_config" | jq -r .networks.podman2.static_ips[0])
 	b_gw=$(echo "$b1_config" | jq -r .network_info.podman2.subnets[0].gateway)
@@ -56,7 +56,7 @@ load helpers
 	subnet_b=$(random_subnet 5)
 
 	# A1
-	create_config "podman1" $(random_string 64) "aone" "$subnet_a" ""
+	create_config network_name="podman1" container_id=$(random_string 64) container_name="aone" subnet="$subnet_a"
 	a1_config=$config
 	a1_container_id=$(echo "$a1_config" | jq -r .container_id)
 	a1_ip=$(echo "$a1_config" | jq -r .networks.podman1.static_ips[0])
@@ -66,7 +66,7 @@ load helpers
 	a1_pid=$CONTAINER_NS_PID
 
 	# container b1 on subnet b
-	create_config "podman2" $(random_string 64) "bone" "$subnet_b" ""
+	create_config network_name="podman2" container_id=$(random_string 64) container_name="bone" subnet="$subnet_b"
 	b1_config=$config
 	b1_ip=$(echo "$b1_config" | jq -r .networks.podman2.static_ips[0])
 	b_gw=$(echo "$b1_config" | jq -r .network_info.podman2.subnets[0].gateway)
@@ -76,7 +76,7 @@ load helpers
 	b_subnets=$(echo $b1_config | jq -r .network_info.podman2.subnets[0])
 
 	# AB2
-	create_config "podman1" $(random_string 64) "abtwo" "$subnet_a" ""
+	create_config network_name="podman1" container_id=$(random_string 64) container_name="abtwo" subnet="$subnet_a"
 	a2_config=$config
 	a2_ip=$(echo "$a2_config" | jq -r .networks.podman1.static_ips[0])
 

--- a/test/300-three-networks.bats
+++ b/test/300-three-networks.bats
@@ -10,7 +10,7 @@ load helpers
 	subnet_b=$(random_subnet 5)
 
 	# A1
-	create_config "podman1" $(random_string 64) "aone" "$subnet_a" ""
+	create_config network_name="podman1" container_id=$(random_string 64) container_name="aone" subnet="$subnet_a"
 	a1_config=$config
 	a1_container_id=$(echo "$a1_config" | jq -r .container_id)
 	a1_ip=$(echo "$a1_config" | jq -r .networks.podman1.static_ips[0])
@@ -20,7 +20,7 @@ load helpers
 	a1_pid=$CONTAINER_NS_PID
 
 	# container b1 on subnet b
-	create_config "podman2" $(random_string 64) "bone" "$subnet_b" ""
+	create_config network_name="podman2" container_id=$(random_string 64) container_name="bone" subnet="$subnet_b"
 	b1_config=$config
 	b1_ip=$(echo "$b1_config" | jq -r .networks.podman2.static_ips[0])
 	b_gw=$(echo "$b1_config" | jq -r .network_info.podman2.subnets[0].gateway)
@@ -30,7 +30,7 @@ load helpers
 	b_subnets=$(echo $b1_config | jq -r .network_info.podman2.subnets[0])
 
 	# AB2
-	create_config "podman1" $(random_string 64) "abtwo" "$subnet_a" ""
+	create_config network_name="podman1" container_id=$(random_string 64) container_name="abtwo" subnet="$subnet_a"
 	a2_config=$config
 	a2_ip=$(echo "$a2_config" | jq -r .networks.podman1.static_ips[0])
 
@@ -83,7 +83,7 @@ load helpers
 	subnet_c=$(random_subnet 5)
 
 	# A1 on subnet A
-	create_config "podman1" $(random_string 64) "aone" "$subnet_a" ""
+	create_config network_name="podman1" container_id=$(random_string 64) container_name="aone" subnet="$subnet_a"
 	a1_config=$config
 	a1_container_id=$(echo "$a1_config" | jq -r .container_id)
 	a1_ip=$(echo "$a1_config" | jq -r .networks.podman1.static_ips[0])
@@ -93,7 +93,7 @@ load helpers
 	a1_pid=$CONTAINER_NS_PID
 
 	# C1 on subnet C
-	create_config "podman3" $(random_string 64) "cone" "$subnet_c" ""
+	create_config network_name="podman3" container_id=$(random_string 64) container_name="cone" subnet="$subnet_c"
 	c1_config=$config
 	c1_container_id=$(echo "$c1_config" | jq -r .container_id)
 	c1_ip=$(echo "$c1_config" | jq -r .networks.podman3.static_ips[0])
@@ -112,7 +112,7 @@ load helpers
 	# the order should be OK.
 
 	# Create B1 config for network connect
-	create_config "podman2" $(random_string 64) "aone" "$subnet_b" "" "aone_nw"
+	create_config network_name="podman2" container_id=$(random_string 64) container_name="aone" subnet="$subnet_b" aliases='"aone_nw"'
 	b1_config=$config
 	# The container ID should be the same
 	b1_config=$(jq ".container_id  |= \"$a1_container_id\"" <<<"$b1_config")
@@ -128,7 +128,7 @@ load helpers
 
 	# Create B2 config for network connect
 	#
-	create_config "podman2" $(random_string 64) "cone" "$subnet_b" "" "cone_nw"
+	create_config network_name="podman2" container_id=$(random_string 64) container_name="cone" subnet="$subnet_b" aliases='"cone_nw"'
 	b2_config=$config
 	# The container ID should be the same
 	b2_config=$(jq ".container_id  |= \"$c1_container_id\"" <<<"$b2_config")
@@ -183,7 +183,7 @@ load helpers
 	subnet_c=$(random_subnet 6)
 
 	# A1 on subnet A
-	create_config "podman1" $(random_string 64) "aone" "$subnet_a" ""
+	create_config network_name="podman1" container_id=$(random_string 64) container_name="aone" subnet="$subnet_a"
 	a1_config=$config
 	a1_container_id=$(echo "$a1_config" | jq -r .container_id)
 	a1_ip=$(echo "$a1_config" | jq -r .networks.podman1.static_ips[0])
@@ -193,7 +193,7 @@ load helpers
 	a1_pid=$CONTAINER_NS_PID
 
 	# C1 on subnet C
-	create_config "podman3" $(random_string 64) "cone" "$subnet_c" ""
+	create_config network_name="podman3" container_id=$(random_string 64) container_name="cone" subnet="$subnet_c"
 	c1_config=$config
 	c1_container_id=$(echo "$c1_config" | jq -r .container_id)
 	c1_ip=$(echo "$c1_config" | jq -r .networks.podman3.static_ips[0])
@@ -207,7 +207,7 @@ load helpers
 	# a network connect on both to B.
 
 	# Create B1 config for network connect
-	create_config "podman2" $(random_string 64) "aone" "$subnet_b" "" "aone_nw"
+	create_config network_name="podman2" container_id=$(random_string 64) container_name="aone" subnet="$subnet_b" aliases='"aone_nw"'
 	b1_config=$config
 	# The container ID should be the same
 	b1_config=$(jq ".container_id  |= \"$a1_container_id\"" <<<"$b1_config")
@@ -223,7 +223,7 @@ load helpers
 
 	# Create B2 config for network connect
 	#
-	create_config "podman2" $(random_string 64) "cone" "$subnet_b" "" "cone_nw"
+	create_config network_name="podman2" container_id=$(random_string 64) container_name="cone" subnet="$subnet_b" aliases='"cone_nw"'
 	b2_config=$config
 	# The container ID should be the same
 	b2_config=$(jq ".container_id  |= \"$c1_container_id\"" <<<"$b2_config")

--- a/test/300-three-networks.bats
+++ b/test/300-three-networks.bats
@@ -10,7 +10,7 @@ load helpers
 	subnet_b=$(random_subnet 5)
 
 	# A1
-	create_config "podman1" $(random_string 64) "aone" "$subnet_a"
+	create_config "podman1" $(random_string 64) "aone" "$subnet_a" ""
 	a1_config=$config
 	a1_container_id=$(echo "$a1_config" | jq -r .container_id)
 	a1_ip=$(echo "$a1_config" | jq -r .networks.podman1.static_ips[0])
@@ -20,7 +20,7 @@ load helpers
 	a1_pid=$CONTAINER_NS_PID
 
 	# container b1 on subnet b
-	create_config "podman2" $(random_string 64) "bone" "$subnet_b"
+	create_config "podman2" $(random_string 64) "bone" "$subnet_b" ""
 	b1_config=$config
 	b1_ip=$(echo "$b1_config" | jq -r .networks.podman2.static_ips[0])
 	b_gw=$(echo "$b1_config" | jq -r .network_info.podman2.subnets[0].gateway)
@@ -30,7 +30,7 @@ load helpers
 	b_subnets=$(echo $b1_config | jq -r .network_info.podman2.subnets[0])
 
 	# AB2
-	create_config "podman1" $(random_string 64) "abtwo" "$subnet_a"
+	create_config "podman1" $(random_string 64) "abtwo" "$subnet_a" ""
 	a2_config=$config
 	a2_ip=$(echo "$a2_config" | jq -r .networks.podman1.static_ips[0])
 
@@ -83,7 +83,7 @@ load helpers
 	subnet_c=$(random_subnet 5)
 
 	# A1 on subnet A
-	create_config "podman1" $(random_string 64) "aone" "$subnet_a"
+	create_config "podman1" $(random_string 64) "aone" "$subnet_a" ""
 	a1_config=$config
 	a1_container_id=$(echo "$a1_config" | jq -r .container_id)
 	a1_ip=$(echo "$a1_config" | jq -r .networks.podman1.static_ips[0])
@@ -93,7 +93,7 @@ load helpers
 	a1_pid=$CONTAINER_NS_PID
 
 	# C1 on subnet C
-	create_config "podman3" $(random_string 64) "cone" "$subnet_c"
+	create_config "podman3" $(random_string 64) "cone" "$subnet_c" ""
 	c1_config=$config
 	c1_container_id=$(echo "$c1_config" | jq -r .container_id)
 	c1_ip=$(echo "$c1_config" | jq -r .networks.podman3.static_ips[0])
@@ -112,7 +112,7 @@ load helpers
 	# the order should be OK.
 
 	# Create B1 config for network connect
-	create_config "podman2" $(random_string 64) "aone" "$subnet_b" "aone_nw"
+	create_config "podman2" $(random_string 64) "aone" "$subnet_b" "" "aone_nw"
 	b1_config=$config
 	# The container ID should be the same
 	b1_config=$(jq ".container_id  |= \"$a1_container_id\"" <<<"$b1_config")
@@ -128,7 +128,7 @@ load helpers
 
 	# Create B2 config for network connect
 	#
-	create_config "podman2" $(random_string 64) "cone" "$subnet_b" "cone_nw"
+	create_config "podman2" $(random_string 64) "cone" "$subnet_b" "" "cone_nw"
 	b2_config=$config
 	# The container ID should be the same
 	b2_config=$(jq ".container_id  |= \"$c1_container_id\"" <<<"$b2_config")
@@ -183,7 +183,7 @@ load helpers
 	subnet_c=$(random_subnet 6)
 
 	# A1 on subnet A
-	create_config "podman1" $(random_string 64) "aone" "$subnet_a"
+	create_config "podman1" $(random_string 64) "aone" "$subnet_a" ""
 	a1_config=$config
 	a1_container_id=$(echo "$a1_config" | jq -r .container_id)
 	a1_ip=$(echo "$a1_config" | jq -r .networks.podman1.static_ips[0])
@@ -193,7 +193,7 @@ load helpers
 	a1_pid=$CONTAINER_NS_PID
 
 	# C1 on subnet C
-	create_config "podman3" $(random_string 64) "cone" "$subnet_c"
+	create_config "podman3" $(random_string 64) "cone" "$subnet_c" ""
 	c1_config=$config
 	c1_container_id=$(echo "$c1_config" | jq -r .container_id)
 	c1_ip=$(echo "$c1_config" | jq -r .networks.podman3.static_ips[0])
@@ -207,7 +207,7 @@ load helpers
 	# a network connect on both to B.
 
 	# Create B1 config for network connect
-	create_config "podman2" $(random_string 64) "aone" "$subnet_b" "aone_nw"
+	create_config "podman2" $(random_string 64) "aone" "$subnet_b" "" "aone_nw"
 	b1_config=$config
 	# The container ID should be the same
 	b1_config=$(jq ".container_id  |= \"$a1_container_id\"" <<<"$b1_config")
@@ -223,7 +223,7 @@ load helpers
 
 	# Create B2 config for network connect
 	#
-	create_config "podman2" $(random_string 64) "cone" "$subnet_b" "cone_nw"
+	create_config "podman2" $(random_string 64) "cone" "$subnet_b" "" "cone_nw"
 	b2_config=$config
 	# The container ID should be the same
 	b2_config=$(jq ".container_id  |= \"$c1_container_id\"" <<<"$b2_config")

--- a/test/400-aliases.bats
+++ b/test/400-aliases.bats
@@ -8,7 +8,7 @@ load helpers
 @test "two containers on the same network with aliases" {
 	# container a1
 	subnet_a=$(random_subnet 5)
-	create_config "podman1" $(random_string 64) "aone" "$subnet_a" "" "a1" "1a"
+	create_config network_name="podman1" container_id=$(random_string 64) container_name="aone" subnet="$subnet_a" aliases='"a1", "1a"'
 	config_a1="$config"
 	a1_ip=$(echo "$config_a1" | jq -r .networks.podman1.static_ips[0])
 	gw=$(echo "$config_a1" | jq -r .network_info.podman1.subnets[0].gateway)
@@ -16,7 +16,7 @@ load helpers
 	a1_pid=$CONTAINER_NS_PID
 
 	# container a2
-	create_config "podman1" $(random_string 64) "atwo" "$subnet_a" "" "a2" "2a"
+	create_config network_name="podman1" container_id=$(random_string 64) container_name="atwo" subnet="$subnet_a" aliases='"a2", "2a"'
 	config_a2="$config"
 	a2_ip=$(echo "$config_a2" | jq -r .networks.podman1.static_ips[0])
 	create_container "$config_a2"

--- a/test/400-aliases.bats
+++ b/test/400-aliases.bats
@@ -8,7 +8,7 @@ load helpers
 @test "two containers on the same network with aliases" {
 	# container a1
 	subnet_a=$(random_subnet 5)
-	create_config "podman1" $(random_string 64) "aone" "$subnet_a" "a1" "1a"
+	create_config "podman1" $(random_string 64) "aone" "$subnet_a" "" "a1" "1a"
 	config_a1="$config"
 	a1_ip=$(echo "$config_a1" | jq -r .networks.podman1.static_ips[0])
 	gw=$(echo "$config_a1" | jq -r .network_info.podman1.subnets[0].gateway)
@@ -16,7 +16,7 @@ load helpers
 	a1_pid=$CONTAINER_NS_PID
 
 	# container a2
-	create_config "podman1" $(random_string 64) "atwo" "$subnet_a" "a2" "2a"
+	create_config "podman1" $(random_string 64) "atwo" "$subnet_a" "" "a2" "2a"
 	config_a2="$config"
 	a2_ip=$(echo "$config_a2" | jq -r .networks.podman1.static_ips[0])
 	create_container "$config_a2"

--- a/test/500-reverse-lookups.bats
+++ b/test/500-reverse-lookups.bats
@@ -8,7 +8,7 @@ load helpers
 @test "check reverse lookups" {
 	# container a1
 	subnet_a=$(random_subnet 5)
-	create_config "podman1" $(random_string 64) "aone" "$subnet_a" "" "a1" "1a"
+	create_config network_name="podman1" container_id=$(random_string 64) container_name="aone" subnet="$subnet_a" aliases='"a1", "1a"'
 	a1_config="$config"
 	a1_ip=$(echo "$a1_config" | jq -r .networks.podman1.static_ips[0])
 	gw=$(echo "$a1_config" | jq -r .network_info.podman1.subnets[0].gateway)
@@ -16,7 +16,7 @@ load helpers
 	a1_pid=$CONTAINER_NS_PID
 
 	# container a2
-	create_config "podman1" $(random_string 64) "atwo" "$subnet_a" "" "a2" "2a"
+	create_config network_name="podman1" container_id=$(random_string 64) container_name="atwo" subnet="$subnet_a" aliases='"a2", "2a"'
 	a2_config="$config"
 	a2_ip=$(echo "$a2_config" | jq -r .networks.podman1.static_ips[0])
 	create_container "$a2_config"
@@ -39,7 +39,7 @@ load helpers
 @test "check reverse lookups on ipaddress v6" {
 	# container a1
 	subnet_a=$(random_subnet 6)
-	create_config "podman1" $(random_string 64) "aone" "$subnet_a" "" "a1" "1a"
+	create_config network_name="podman1" container_id=$(random_string 64) container_name="aone" subnet="$subnet_a" aliases='"a1", "1a"'
 	a1_config="$config"
 	a1_ip=$(echo "$a1_config" | jq -r .networks.podman1.static_ips[0])
 	gw=$(echo "$a1_config" | jq -r .network_info.podman1.subnets[0].gateway)
@@ -47,7 +47,7 @@ load helpers
 	a1_pid=$CONTAINER_NS_PID
 
 	# container a2
-	create_config "podman1" $(random_string 64) "atwo" "$subnet_a" "" "a2" "2a"
+	create_config network_name="podman1" container_id=$(random_string 64) container_name="atwo" subnet="$subnet_a" aliases='"a2", "2a"'
 	a2_config="$config"
 	a2_ip=$(echo "$a2_config" | jq -r .networks.podman1.static_ips[0])
 	create_container "$a2_config"

--- a/test/500-reverse-lookups.bats
+++ b/test/500-reverse-lookups.bats
@@ -8,7 +8,7 @@ load helpers
 @test "check reverse lookups" {
 	# container a1
 	subnet_a=$(random_subnet 5)
-	create_config "podman1" $(random_string 64) "aone" "$subnet_a" "a1" "1a"
+	create_config "podman1" $(random_string 64) "aone" "$subnet_a" "" "a1" "1a"
 	a1_config="$config"
 	a1_ip=$(echo "$a1_config" | jq -r .networks.podman1.static_ips[0])
 	gw=$(echo "$a1_config" | jq -r .network_info.podman1.subnets[0].gateway)
@@ -16,7 +16,7 @@ load helpers
 	a1_pid=$CONTAINER_NS_PID
 
 	# container a2
-	create_config "podman1" $(random_string 64) "atwo" "$subnet_a" "a2" "2a"
+	create_config "podman1" $(random_string 64) "atwo" "$subnet_a" "" "a2" "2a"
 	a2_config="$config"
 	a2_ip=$(echo "$a2_config" | jq -r .networks.podman1.static_ips[0])
 	create_container "$a2_config"
@@ -39,7 +39,7 @@ load helpers
 @test "check reverse lookups on ipaddress v6" {
 	# container a1
 	subnet_a=$(random_subnet 6)
-	create_config "podman1" $(random_string 64) "aone" "$subnet_a" "a1" "1a"
+	create_config "podman1" $(random_string 64) "aone" "$subnet_a" "" "a1" "1a"
 	a1_config="$config"
 	a1_ip=$(echo "$a1_config" | jq -r .networks.podman1.static_ips[0])
 	gw=$(echo "$a1_config" | jq -r .network_info.podman1.subnets[0].gateway)
@@ -47,7 +47,7 @@ load helpers
 	a1_pid=$CONTAINER_NS_PID
 
 	# container a2
-	create_config "podman1" $(random_string 64) "atwo" "$subnet_a" "a2" "2a"
+	create_config "podman1" $(random_string 64) "atwo" "$subnet_a" "" "a2" "2a"
 	a2_config="$config"
 	a2_ip=$(echo "$a2_config" | jq -r .networks.podman1.static_ips[0])
 	create_container "$a2_config"

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -355,7 +355,8 @@ function run_in_host_netns() {
 # second arg is container_id
 # third is container name
 # fourth is subnet
-# fifth and greater are aliases
+# fifth is custom dns server for container (empty will not be used)
+# sixth and greater are aliases
 function create_config() {
     local network_name=$1
     shift
@@ -366,6 +367,12 @@ function create_config() {
 
     local subnets=""
     local subnet=$1
+    shift
+    local custom_dns_server
+    #local dns_server=$1
+    if [ -n "$1" ]; then
+	    custom_dns_server=\"$1\"
+    fi
     shift
     container_ip=$(random_ip_in_subnet $subnet)
     container_gw=$(gateway_from_subnet $subnet)
@@ -389,7 +396,8 @@ function create_config() {
   },
   "network_info": {
       $new_network_info
-  }
+  },
+  "dns_servers": [$custom_dns_server]
 }\0
 EOF
 


### PR DESCRIPTION
Aardvark-dns's config now allows containers to define a list of one of more custom `DNS` servers. If custom `DNS` servers are specified for a container aardvark-dns will use these custom DNS servers are resolver instead of host's default revolvers.
* Newly added field to aardvark-dns's config is optional in nature.

### How to verify
 - See newly added `integration` and `unit` tests.
 - Makes `podman run -it --rm --network test --dns 8.8.8.8 ctr dig google.com` to use `8.8.8.8` as a resolver instead of host's configured resolver.