### PR TITLE
Reduce tokio and futures-util features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,17 +239,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
-name = "futures-macro"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "futures-task"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,7 +251,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
  "futures-core",
- "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
@@ -831,9 +819,7 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ trust-dns-server = "0.22.0"
 trust-dns-proto = "0.20.4"
 trust-dns-client = "0.20.4"
 anyhow = "1.0.65"
-futures-util = "0.3.24"
+futures-util = { version = "0.3.24", default-features = false }
 signal-hook = "0.3.13"
-tokio = { version = "1.21.2", features = ["tokio-macros", "full"] }
+tokio = { version = "1.21.2", features = ["macros", "rt-multi-thread", "net"] }
 async-broadcast = "0.4.1"
 resolv-conf = "0.7.0"
 nix = "0.25.0"


### PR DESCRIPTION
Reduces the features enabled by tokio and futures-util in order to optimize the build process. This currently don't result into any substantial change but it'll improve once downstream crates apply the same optimizations.