### PR TITLE
Ci image update

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,7 +19,7 @@ env:
     NETAVARK_URL: "https://api.cirrus-ci.com/v1/artifact/github/containers/netavark/success/binary.zip?branch=${NETAVARK_BRANCH}"
     # Save a little typing (path relative to $CIRRUS_WORKING_DIR)
     SCRIPT_BASE: "./contrib/cirrus"
-    IMAGE_SUFFIX: "c6535313974624256"
+    IMAGE_SUFFIX: "c5518085466095616"
     FEDORA_NETAVARK_IMAGE: "fedora-netavark-${IMAGE_SUFFIX}"
     FEDORA_NETAVARK_AMI: "fedora-netavark-aws-arm64-${IMAGE_SUFFIX}"
     EC2_INST_TYPE: "t4g.xlarge"

--- a/build.rs
+++ b/build.rs
@@ -24,7 +24,7 @@ fn main() {
     );
 
     // get git commit
-    let command = Command::new("git").args(&["rev-parse", "HEAD"]).output();
+    let command = Command::new("git").args(["rev-parse", "HEAD"]).output();
     let commit = match command {
         Ok(output) => String::from_utf8(output.stdout).unwrap(),
         // if error, e.g. build from source with git repo, just show empty string

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -69,7 +69,7 @@ fn core_serve_loop(
     port: u32,
     filter_search_domain: &str,
 ) -> Result<(), std::io::Error> {
-    let mut signals = Signals::new(&[SIGHUP])?;
+    let mut signals = Signals::new([SIGHUP])?;
 
     match config::parse_configs(config_path) {
         Ok((backend, listen_ip_v4, listen_ip_v6)) => {


### PR DESCRIPTION
Bumps the fedora version to 37 and includes a rust update to 1.65.
Fixes the newly reported lint issues as well.