### PR TITLE
[skip-ci] GHA/Cirrus-cron: Fix execution order

### DIFF
--- a/.github/workflows/check_cirrus_cron.yml
+++ b/.github/workflows/check_cirrus_cron.yml
@@ -9,7 +9,7 @@ on:
     # N/B: This should correspond to a period slightly after
     # the last job finishes running.  See job defs. at:
     # https://cirrus-ci.com/settings/repository/5268168076689408
-    - cron:  '59 23 * * 1-5'
+    - cron:  '03 03 * * 1-5'
   # Debug: Allow triggering job manually in github-actions WebUI
   workflow_dispatch: {}
 

--- a/.github/workflows/rerun_cirrus_cron.yml
+++ b/.github/workflows/rerun_cirrus_cron.yml
@@ -8,7 +8,7 @@ on:
     # N/B: This should correspond to a period slightly after
     # the last job finishes running.  See job defs. at:
     # https://cirrus-ci.com/settings/repository/5268168076689408
-    - cron:  '05 22 * * 1-5'
+    - cron:  '01 01 * * 1-5'
   # Debug: Allow triggering job manually in github-actions WebUI
   workflow_dispatch: {}
 


### PR DESCRIPTION
Fairly universally, the last Cirrus-Cron job is set to fire off at 22:22 UTC.  However, the re-run of failed jobs GHA workflow was scheduled for 22:05, meaning it will never re-run the last cirrus-cron job should it fail.

Re-arrange the execution order so as to give plenty of time between the last cirrus-cron job starting, the auto-re-run attempt, and the final failure-check e-mail.

Signed-off-by: Chris Evich <cevich@redhat.com>