### PR TITLE
Kill the chicken and egg part 2

### DIFF
--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -19,19 +19,11 @@ msg "Setting up runtime environment"
 msg "************************************************************"
 show_env_vars
 
-req_env_vars NETAVARK_URL
 
 set -x  # show what's happening
-curl --fail --location -o /tmp/netavark.zip "$NETAVARK_URL"
 mkdir -p /usr/libexec/podman
-cd /usr/libexec/podman
-unzip -o /tmp/netavark.zip
-if [[ $(uname -m) != "x86_64" ]]; then
-    mv netavark.$(uname -m)-unknown-linux-gnu netavark
-fi
-chmod a+x /usr/libexec/podman/netavark
-# show netavark commit in CI logs
-/usr/libexec/podman/netavark version
+cargo install --root /usr/libexec/podman --git https://github.com/containers/netavark
+mv /usr/libexec/podman/bin/netavark /usr/libexec/podman/
 
 # Warning, this isn't the end.  An exit-handler is installed to finalize
 # setup of env. vars.  This is required for runner.sh to operate properly.


### PR DESCRIPTION
Reliable CI cannot depend on another task always working when there is a chicken and egg dependency between them., Just build the netavark binary.

Signed-off-by: Brent Baude <bbaude@redhat.com>