### PR TITLE
Switch to explicit platform list for `cargo vendor-filterer`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,13 @@ repository = "https://github.com/containers/aardvark-dns"
 categories = ["containers", "networking", "dns", "podman"]
 exclude = ["/.cirrus.yml", "/.github/*"]
 
+[package.metadata.vendor-filter]
+# This list is not exhaustive.
+platforms = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "powerpc64le-unknown-linux-gnu",
+             "s390x-unknown-linux-gnu", "riscv64gc-unknown-linux-gnu",
+             "x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl",
+             ]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ validate: $(CARGO_TARGET_DIR)
 .PHONY: vendor-tarball
 vendor-tarball: build install.cargo-vendor-filterer
 	VERSION=$(shell bin/aardvark-dns --version | cut -f2 -d" ") && \
-	cargo vendor-filterer '--platform=*-unknown-linux-*' --format=tar.gz --prefix vendor/ && \
+	cargo vendor-filterer --format=tar.gz --prefix vendor/ && \
 	mv vendor.tar.gz aardvark-dns-v$$VERSION-vendor.tar.gz && \
 	gzip -c bin/aardvark-dns > aardvark-dns.gz && \
 	sha256sum aardvark-dns.gz aardvark-dns-v$$VERSION-vendor.tar.gz > sha256sum


### PR DESCRIPTION
See https://github.com/coreos/cargo-vendor-filterer/issues/50 This fixes an error trying to vendor for m68k.

Also while we have the patient open, move the platform list to `Cargo.toml` in declarative format.

Copied as is from https://github.com/containers/netavark/pull/568 by Colin Walters <walters@verbum.org>

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>