### PR TITLE
[CI:BUILD] Packit: trigger builds on commit to main branch

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -8,7 +8,8 @@
 specfile_path: aardvark-dns.spec
 
 jobs:
-  - job: copr_build
+  - &copr
+    job: copr_build
     trigger: pull_request
     owner: rhcontainerbot
     project: packit-builds
@@ -23,3 +24,9 @@ jobs:
         - "rpkg spec --outdir ./"
       fix-spec-file:
         - "bash .packit.sh"
+
+  - <<: *copr
+    # Run on commit to main branch
+    trigger: commit
+    branch: main
+    project: podman-next


### PR DESCRIPTION
This commit basically lets packit trigger builds on `rhcontainerbot/podman-next` copr after a commit to the main branch instead of the current github webhook trigger.

The builds triggered via packit also provide more information in their `version-release`:

Current webhook triggered build:
`101:0.0.git.459.7af4e6ca-1`

Packit triggered build:
`101:1.6.0~dev-1.20230320051048640346.pr303.22.g075e095`

The packit triggered build correctly shows the PR#, commit id, timestamp as well as the upstream version.