### PR TITLE
fix typo in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ build: bin $(CARGO_TARGET_DIR)
 
 .PHONY: crate-publish
 crate-publish:
-	@if [ "$(CRATE_VERSION)" != "$(GIT_TAG)" ]; then\
+	@if [ "v$(CRATE_VERSION)" != "$(GIT_TAG)" ]; then\
 		echo "Git tag is not equivalent to the version set in Cargo.toml. Please checkout the correct tag";\
 		exit 1;\
 	fi


### PR DESCRIPTION
the crate publish target in the makefile has a small typo where it was comparing two variables for version but one always had a prefix of `v`.