### PR TITLE
[CI:BUILD] rpm: spdx compatible license field

### DIFF
--- a/rpm/aardvark-dns.spec
+++ b/rpm/aardvark-dns.spec
@@ -29,7 +29,8 @@ Epoch: 102
 # copr and koji builds.
 # If you're reading this on dist-git, the version is automatically filled in by Packit.
 Version: 0
-License: Apache-2.0 and MIT and Zlib
+# The `AND` needs to be uppercase in the License for SPDX compatibility
+License: Apache-2.0 AND MIT AND Zlib
 Release: %autorelease
 %if %{defined golang_arches_future}
 ExclusiveArch: %{golang_arches_future}


### PR DESCRIPTION
The lowercase `and` in the License field isn't compatible with spdx license format.

This commit replaces all `and` with `AND` in the License field in spec.

[NO NEW TESTS NEEDED]