### PR TITLE
cargo: bump chrono to `0.4.30`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,17 +188,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
- "time 0.1.45",
  "wasm-bindgen",
- "winapi",
+ "windows-targets",
 ]
 
 [[package]]
@@ -397,7 +396,7 @@ checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -577,7 +576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys",
 ]
 
@@ -861,7 +860,7 @@ dependencies = [
  "hostname",
  "libc",
  "log",
- "time 0.3.22",
+ "time",
 ]
 
 [[package]]
@@ -882,17 +881,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
 ]
 
 [[package]]
@@ -1092,7 +1080,7 @@ dependencies = [
  "futures-util",
  "serde",
  "thiserror",
- "time 0.3.22",
+ "time",
  "tokio",
  "toml",
  "tracing",
@@ -1142,12 +1130,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,4 +38,4 @@ nix = { version = "0.27.1", features = ["fs", "signal"] }
 libc = "0.2"
 
 [build-dependencies]
-chrono = "0.4.26"
+chrono = "0.4.30"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
 use std::env;
 use std::process::Command;
 
@@ -10,7 +10,7 @@ fn main() {
     let now = match env::var("SOURCE_DATE_EPOCH") {
         Ok(val) => {
             let naive = NaiveDateTime::from_timestamp_opt(val.parse::<i64>().unwrap(), 0).unwrap();
-            let datetime: DateTime<Utc> = DateTime::from_utc(naive, Utc);
+            let datetime: DateTime<Utc> = TimeZone::from_utc_datetime(&Utc, &naive);
             datetime
         }
         Err(_) => Utc::now(),


### PR DESCRIPTION
Closes: https://github.com/containers/aardvark-dns/pull/378/files