### PR TITLE
[CI:DOCS] Packit: disable bodhi tasks

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -117,7 +117,10 @@ jobs:
     dist_git_branches:
       - fedora-all
 
-  - job: bodhi_update
-    trigger: commit
-    dist_git_branches:
-      - fedora-branched # rawhide updates are created automatically
+        # NOTE: Bodhi update tasks are disabled to allow netavark and aardvark-dns X.Y
+        # builds in a single manual bodhi update. Leaving this commented out
+        # but not deleted so it's not forgotten.
+        #- job: bodhi_update
+        #trigger: commit
+        #dist_git_branches:
+        #- fedora-branched # rawhide updates are created automatically


### PR DESCRIPTION
This allows manual submission of a single bodhi update containing netavark and aardvark-dns X.Y builds.


@Luap99 PTAL

Netavark will have a similar PR with additional dep handling in its spec.