### PR TITLE
Add names for domains in answers in reverse lookups

### DIFF
--- a/contrib/cirrus/runner.sh
+++ b/contrib/cirrus/runner.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 # This script runs in the Cirrus CI environment, invoked from .cirrus.yml .
-# It can also be invoked manually in a `hack/get_ci_cm.sh` environment,
+# It can also be invoked manually in a `hack/get_ci_vm.sh` environment,
 # documentation of said usage is TBI.
 #
 # The principal deciding factor is the first argument.  For any

--- a/src/dns/coredns.rs
+++ b/src/dns/coredns.rs
@@ -211,6 +211,7 @@ impl CoreDns {
                                             if let Ok(answer) = Name::from_ascii(format!("{}.", entry)) {
                                                 req_clone.add_answer(
                                                     Record::new()
+                                                        .set_name(Name::from_str_relaxed(&name).unwrap_or_default())
                                                         .set_ttl(CONTAINER_TTL)
                                                         .set_rr_type(RecordType::PTR)
                                                         .set_dns_class(DNSClass::IN)

--- a/src/dns/coredns.rs
+++ b/src/dns/coredns.rs
@@ -202,7 +202,7 @@ impl CoreDns {
                                     ptr_lookup_ip = String::from("not an ip");
                                 }
 
-                                trace!("Performing lookup reverse lookup for ip: {:?}", ptr_lookup_ip.to_owned());
+                                trace!("Performing reverse lookup for ip: {:?}", ptr_lookup_ip.to_owned());
                                 // We should probably log malformed queries, but for now if-let should be fine.
                                 if let Ok(lookup_ip) = ptr_lookup_ip.parse() {
                                     if let Some(reverse_lookup) = self.backend.reverse_lookup(&src_address.ip(), &lookup_ip) {

--- a/test/500-reverse-lookups.bats
+++ b/test/500-reverse-lookups.bats
@@ -22,18 +22,22 @@ load helpers
 	create_container "$a2_config"
 	a2_pid="$CONTAINER_NS_PID"
 
-	echo "$a1_config"
-	echo "$a2_config"
+	echo "a1 config:\n${a1_config}\n"
+	echo "a2 config:\n${a2_config}\n"
 
 	# Resolve IPs to container names
 	dig_reverse "$a1_pid" "$a2_ip" "$gw"
-	assert "$output" =~ "atwo"
-	assert "$output" =~ "a2"
-	assert "$output" =~ "2a"
+	echo -e "Output:\n${output}\n"
+	a2_expected_name=$(echo $a2_ip | awk -F. '{printf "%d.%d.%d.%d.in-addr.arpa.", $4, $3, $2, $1}')
+	assert "$output" =~ "$a2_expected_name[ 	].*[ 	]atwo\."
+	assert "$output" =~ "$a2_expected_name[ 	].*[ 	]a2\."
+	assert "$output" =~ "$a2_expected_name[ 	].*[ 	]2a\."
 	dig_reverse "$a2_pid" "$a1_ip" "$gw"
-	assert "$output" =~ "aone"
-	assert "$output" =~ "a1"
-	assert "$output" =~ "1a"
+	echo -e "Output:\n${output}\n"
+	a1_expected_name=$(echo $a1_ip | awk -F. '{printf "%d.%d.%d.%d.in-addr.arpa.", $4, $3, $2, $1}')
+	assert "$output" =~ "$a1_expected_name[ 	].*[ 	]aone\."
+	assert "$output" =~ "$a1_expected_name[ 	].*[ 	]a1\."
+	assert "$output" =~ "$a1_expected_name[ 	].*[ 	]1a\."
 }
 
 @test "check reverse lookups on ipaddress v6" {
@@ -57,12 +61,13 @@ load helpers
 	echo "$a2_config"
 
 	# Resolve IPs to container names
+	# It is much harder to construct the arpa address in ipv6 so we just check that we are in the fd::/8 range
 	dig_reverse "$a1_pid" "$a2_ip" "$gw"
-	assert "$output" =~ "atwo"
-	assert "$output" =~ "a2"
-	assert "$output" =~ "2a"
+	assert "$output" =~ '([0-9a-f]\.){30}d\.f\.ip6\.arpa\.[ 	].*[ 	]atwo\.'
+	assert "$output" =~ '([0-9a-f]\.){30}d\.f\.ip6\.arpa\.[ 	].*[ 	]a2\.'
+	assert "$output" =~ '([0-9a-f]\.){30}d\.f\.ip6\.arpa\.[ 	].*[ 	]2a\.'
 	dig_reverse "$a2_pid" "$a1_ip" "$gw"
-	assert "$output" =~ "aone"
-	assert "$output" =~ "a1"
-	assert "$output" =~ "1a"
+	assert "$output" =~ '([0-9a-f]\.){30}d\.f\.ip6\.arpa\.[ 	].*[ 	]aone\.'
+	assert "$output" =~ '([0-9a-f]\.){30}d\.f\.ip6\.arpa\.[ 	].*[ 	]a1\.'
+	assert "$output" =~ '([0-9a-f]\.){30}d\.f\.ip6\.arpa\.[ 	].*[ 	]1a\.'
 }

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -597,8 +597,7 @@ function dig_reverse() {
     # first arg is container_netns_pid
     # second arg is the IP address
     # third arg is server addr
-    #run_in_container_netns "$1" "dig" "-x" "$2" "+short" "@$3"
-    run_in_container_netns "$1" "nslookup" "$2" "$3"
+    run_in_container_netns "$1" "dig" "-x" "$2" "@$3"
 }
 
 function setup() {


### PR DESCRIPTION
Closes #436 
Hopefully...

I wasn't able to run `aardvark-dns` locally so I wasn't able to test it. Running `RUST_LOG=trace cargo run -- -c src/test/config/podman -p 5533 run` spawns the background process and the pid file is created but I am unable to query it. Any asistance with that would be appreciated.

I also fixed two typos I have noticed along the way.