### PR TITLE
fix Total success task name

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -231,7 +231,7 @@ centos9_build_task:
 success_task:
   alias: "success"
   gce_instance: *standard_gce_x86_64
-  name: "Total success"
+  name: "Total Success"
   depends_on:
     - "build"
     - "build_aarch64"


### PR DESCRIPTION
Ever since the merge bot change[1] the bot is blocking on the task name, it was set to "Total Success" while this repo had "Total success" so I think this is the reason the bot is no longer merging things here.

[1] https://github.com/openshift/release/commit/74ec1922d6d53e0d2cc25358afff869d258e485d