### PR TITLE
Don't tear down all server threads on SIGHUP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,9 +7,10 @@ name = "aardvark-dns"
 version = "1.11.0-dev"
 dependencies = [
  "anyhow",
- "async-broadcast",
+ "arc-swap",
  "chrono",
  "clap",
+ "flume",
  "futures-util",
  "hickory-client",
  "hickory-proto",
@@ -108,16 +109,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
-name = "async-broadcast"
-version = "0.7.0"
+name = "arc-swap"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258b52a1aa741b9f09783b2d86cf0aeeb617bbf847f6933340a39644227acbdb"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "async-trait"
@@ -248,25 +243,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "concurrent-queue"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "data-encoding"
@@ -311,24 +291,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "5.2.0"
+name = "flume"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
 dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291"
-dependencies = [
- "event-listener",
- "pin-project-lite",
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin",
 ]
 
 [[package]]
@@ -393,8 +364,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -560,6 +533,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "lock_api"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +578,15 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -666,12 +658,6 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "parking"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "percent-encoding"
@@ -783,6 +769,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "serde"
 version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +836,15 @@ checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,10 +32,11 @@ anyhow = "1.0.81"
 futures-util = { version = "0.3.30", default-features = false }
 signal-hook = "0.3.17"
 tokio = { version = "1.37.0", features = ["macros", "rt-multi-thread", "net"] }
-async-broadcast = "0.7.0"
 resolv-conf = "0.7.0"
 nix = { version = "0.28.0", features = ["fs", "signal"] }
 libc = "0.2"
+arc-swap = "1.7.1"
+flume = "0.11.0"
 
 [build-dependencies]
 chrono = "0.4.37"

--- a/src/dns/coredns.rs
+++ b/src/dns/coredns.rs
@@ -1,5 +1,6 @@
 use crate::backend::DNSBackend;
 use crate::backend::DNSResult;
+use arc_swap::ArcSwap;
 use futures_util::StreamExt;
 use futures_util::TryStreamExt;
 use hickory_client::{client::AsyncClient, proto::xfer::SerialMessage, rr::rdata, rr::Name};
@@ -18,7 +19,6 @@ use std::env;
 use std::fs::File;
 use std::io::Read;
 use std::net::{IpAddr, SocketAddr};
-use std::sync::Arc;
 use tokio::net::UdpSocket;
 
 // Containers can be recreated with different ips quickly so
@@ -28,14 +28,14 @@ use tokio::net::UdpSocket;
 const CONTAINER_TTL: u32 = 60;
 
 pub struct CoreDns {
-    name: Name,                          // name or origin
-    network_name: String,                // raw network name
-    address: IpAddr,                     // server address
-    port: u32,                           // server port
-    backend: Arc<DNSBackend>,            // server's data store
-    filter_search_domain: String,        // filter_search_domain
-    rx: async_broadcast::Receiver<bool>, // kill switch receiver
-    resolv_conf: resolv_conf::Config,    // host's parsed /etc/resolv.conf
+    name: Name,                            // name or origin
+    network_name: String,                  // raw network name
+    address: IpAddr,                       // server address
+    port: u32,                             // server port
+    backend: &'static ArcSwap<DNSBackend>, // server's data store
+    filter_search_domain: String,          // filter_search_domain
+    rx: flume::Receiver<()>,               // kill switch receiver
+    resolv_conf: resolv_conf::Config,      // host's parsed /etc/resolv.conf
 }
 
 impl CoreDns {
@@ -45,12 +45,12 @@ impl CoreDns {
     pub async fn new(
         address: IpAddr,
         port: u32,
-        network_name: &str,
+        network_name: String,
         forward_addr: IpAddr,
         forward_port: u16,
-        backend: Arc<DNSBackend>,
+        backend: &'static ArcSwap<DNSBackend>,
         filter_search_domain: String,
-        rx: async_broadcast::Receiver<bool>,
+        rx: flume::Receiver<()>,
     ) -> anyhow::Result<Self> {
         // this does not have to be unique, if we fail getting server name later
         // start with empty name
@@ -63,7 +63,7 @@ impl CoreDns {
             if let Ok(n) = Name::parse(&network_name[..10], None) {
                 name = n;
             }
-        } else if let Ok(n) = Name::parse(network_name, None) {
+        } else if let Ok(n) = Name::parse(&network_name, None) {
             name = n;
         }
 
@@ -81,8 +81,6 @@ impl CoreDns {
                 }
             }
         }
-
-        let network_name = network_name.to_owned();
 
         Ok(CoreDns {
             name,
@@ -114,7 +112,7 @@ impl CoreDns {
 
         loop {
             tokio::select! {
-                _ = self.rx.recv() => {
+                _ = self.rx.recv_async() => {
                     break;
                 },
                 v = receiver.next() => {
@@ -128,6 +126,7 @@ impl CoreDns {
                     };
                     match msg_received {
                         Ok(msg) => {
+                            let backend = self.backend.load();
                             let src_address = msg.addr();
                             let mut dns_resolver = self.resolv_conf.clone();
                             let sender = sender_original.clone().with_remote_addr(src_address);
@@ -141,14 +140,14 @@ impl CoreDns {
                             let mut resolved_ip_list: Vec<IpAddr> = Vec::new();
                             let mut nameservers_scoped: Vec<ScopedIp> = Vec::new();
                             // Add resolvers configured for container
-                            if let Some(Some(dns_servers)) = self.backend.ctr_dns_server.get(&src_address.ip()) {
+                            if let Some(Some(dns_servers)) = backend.ctr_dns_server.get(&src_address.ip()) {
                                     if !dns_servers.is_empty() {
                                         for dns_server in dns_servers.iter() {
                                             nameservers_scoped.push(ScopedIp::from(*dns_server));
                                         }
                                     }
                             // Add network scoped resolvers only if container specific resolvers were not configured
-                            } else if let Some(network_dns_servers) = self.backend.get_network_scoped_resolvers(&src_address.ip()) {
+                            } else if let Some(network_dns_servers) = backend.get_network_scoped_resolvers(&src_address.ip()) {
                                         for dns_server in network_dns_servers.iter() {
                                                 nameservers_scoped.push(ScopedIp::from(*dns_server));
                                         }
@@ -167,9 +166,9 @@ impl CoreDns {
                             debug!("checking if backend has entry for: {:?}", name);
                             trace!(
                                 "server backend.name_mappings: {:?}",
-                                self.backend.name_mappings
+                                backend.name_mappings
                             );
-                            trace!("server backend.ip_mappings: {:?}", self.backend.ip_mappings);
+                            trace!("server backend.ip_mappings: {:?}", backend.ip_mappings);
 
 
                             // if record type is PTR try resolving early and return if record found
@@ -205,7 +204,7 @@ impl CoreDns {
                                 trace!("Performing reverse lookup for ip: {:?}", ptr_lookup_ip.to_owned());
                                 // We should probably log malformed queries, but for now if-let should be fine.
                                 if let Ok(lookup_ip) = ptr_lookup_ip.parse() {
-                                    if let Some(reverse_lookup) = self.backend.reverse_lookup(&src_address.ip(), &lookup_ip) {
+                                    if let Some(reverse_lookup) = backend.reverse_lookup(&src_address.ip(), &lookup_ip) {
                                         let mut req_clone = req.clone();
                                         for entry in reverse_lookup {
                                             if let Ok(answer) = Name::from_ascii(format!("{}.", entry)) {
@@ -226,7 +225,7 @@ impl CoreDns {
                             }
 
                             // attempt intra network resolution
-                            match self.backend.lookup(&src_address.ip(), name.as_str()) {
+                            match backend.lookup(&src_address.ip(), name.as_str()) {
                                 // If we go success from backend lookup
                                 DNSResult::Success(_ip_vec) => {
                                     debug!("Found backend lookup");
@@ -237,7 +236,7 @@ impl CoreDns {
                                     debug!(
                                 "No backend lookup found, try resolving in current resolvers entry"
                             );
-                                    if let Some(container_mappings) = self.backend.name_mappings.get(&self.network_name) {
+                                    if let Some(container_mappings) = backend.name_mappings.get(&self.network_name) {
                                         for (key, value) in container_mappings {
 
                                             // if query contains search domain, strip it out.


### PR DESCRIPTION
Instead we parse the new config, replace the in-memory configuration state, stop all old threads for IPs which are no longer in the configuration, and start any new ones for IPs which were added.

Resolves #389.