### PR TITLE
fix reverse ipv6 lookup test flake

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -247,7 +247,7 @@ function random_string() {
 # if "6" is given as first argument it will return a "fdx:x:x:x::/64" ipv6 subnet
 function random_subnet() {
     if [[ "$1" == "6" ]]; then
-        printf "fd%x:%x:%x:%x::/64" $((RANDOM % 256)) $((RANDOM % 65535)) $((RANDOM % 65535)) $((RANDOM % 65535))
+        printf "fd%02x:%x:%x:%x::/64" $((RANDOM % 256)) $((RANDOM % 65535)) $((RANDOM % 65535)) $((RANDOM % 65535))
     else
         printf "10.%d.%d.0/24" $((RANDOM % 256)) $((RANDOM % 256))
     fi


### PR DESCRIPTION
The test assumed that we have a fdxx:... addresses which is what we should be getting normally, however the ipv6 subnet generator had a bug that caused it to create fdx:... sometimes which is different as ipv6 allows us to omit leading zeros, thus we actually have 0fdx which is not in the range we want to use at all.

So simply fix this by creating the proper subnet so that if the random number was less than 16 we add the leading zero add the proper place after fd.