### PR TITLE
[skip-ci] Packit: separate `packages` key for rhel jobs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -12,6 +12,8 @@ packages:
   aardvark-dns-centos:
     pkg_tool: centpkg
     specfile_path: rpm/aardvark-dns.spec
+  aardvark-dns-rhel:
+    specfile_path: rpm/aardvark-dns.spec
 
 srpm_build_deps:
   - cargo
@@ -49,7 +51,7 @@ jobs:
 
   - job: copr_build
     trigger: pull_request
-    packages: [aardvark-dns-centos]
+    packages: [aardvark-dns-rhel]
     notifications: *copr_build_failure_notification
     targets:
       - epel-9-x86_64
@@ -150,7 +152,7 @@ jobs:
   # Integration tests on RHEL
   - job: tests
     trigger: pull_request
-    packages: [aardvark-dns-centos]
+    packages: [aardvark-dns-rhel]
     notifications: *integration_test_failure_notification
     use_internal_tf: true
     targets: *pr_test_targets_rhel


### PR DESCRIPTION
This should prevent status reporting issues as encountered in https://github.com/containers/aardvark-dns/pull/458 . The possible cause for the error was packit getting confused between two separate copr jobs with the same parameters but different targets.

Having a separate `packages` key for rhel jobs should make it easier for packit to do the right thing.

This should also make it possible for CentOS integration tests to run automatically on all PRs and not need manual triggering by a maintainer. Those were not triggered automatically on
https://github.com/containers/aardvark-dns/pull/456 while the Fedora integration tests were.