### PR TITLE
[skip-ci] Packit: use `packages: [aardvark-dns-fedora] for podman-next builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -61,6 +61,7 @@ jobs:
   # Run on commit to main branch
   - job: copr_build
     trigger: commit
+    packages: [aardvark-dns-fedora]
     notifications:
       failure_comment:
         message: "podman-next COPR build failed. @containers/packit-build please check."


### PR DESCRIPTION
Otherwise multiple duplicate jobs are created on the podman-next copr.