### PR TITLE
Release1.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aardvark-dns"
-version = "1.11.0"
+version = "1.12.0-dev"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aardvark-dns"
-version = "1.11.0-dev"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aardvark-dns"
 # This version specification right below is reused by .packit.sh to generate rpm version
-version = "1.11.0-dev"
+version = "1.11.0"
 edition = "2018"
 authors = ["github.com/containers"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aardvark-dns"
 # This version specification right below is reused by .packit.sh to generate rpm version
-version = "1.11.0"
+version = "1.12.0-dev"
 edition = "2018"
 authors = ["github.com/containers"]
 license = "Apache-2.0"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## v1.11.0
+* Do not allow "internal" networks to access DNS
+* On SIGHUP, stop AV threads no longer needed and reload in memory those that are 
+* updated dependencies
+
 ## v1.10.0
 * removed unused kill switch
 * updated dependencies


### PR DESCRIPTION
* Do not allow "internal" networks to access DNS
* On SIGHUP, stop AV threads no longer needed and reload in memory those that are 
* updated dependencies