### PR TITLE
add some basic perf check script

### DIFF
--- a/contrib/perf/nslookup.py
+++ b/contrib/perf/nslookup.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+import socket
+import sys
+
+for i in range(0, 10_000):
+    socket.getaddrinfo(sys.argv[1], 0)

--- a/contrib/perf/run.sh
+++ b/contrib/perf/run.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+PODMAN=${PODMAN-podman}
+DIR=$(dirname -- "${BASH_SOURCE[0]}")
+IMAGE=docker.io/library/python
+JOBS=${JOBS:-$(nproc)}
+netname="testnet"
+
+
+$PODMAN rm -fa -t0
+$PODMAN network rm -f $netname
+
+$PODMAN network create $netname
+
+# first command to spawn aardvark-dns
+$PODMAN run -i -d --network $netname --name starter $IMAGE
+
+perf stat -p $(pgrep -n aardvark-dns) &> $DIR/perf.log &
+
+for i in $( seq 1 $JOBS )
+do
+    $PODMAN run -v $DIR/nslookup.py:/nslookup.py:z --name test$i --network $netname:alias=testabc$i -d $IMAGE /nslookup.py testabc$i
+done
+
+$PODMAN rm -f -t0 starter
+
+# wait for perf to finish
+# because aardvark-dns exists on its own when all containers are done this should not hang
+wait
+
+#
+$PODMAN rm -fa -t0
+$PODMAN network rm -f $netname


### PR DESCRIPTION
Using podman spawn some containers and then check the performance from aardvark-dns.

Comparing results from now after the rework with v1.11 I can see significant gains. While the total time is about the same the new version only uses around 2/3 of the cycles which means cpu utilization is much better now.