### PR TITLE
server: improve parent <-> child error handling 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,6 @@ dependencies = [
  "log",
  "nix",
  "resolv-conf",
- "signal-hook",
  "syslog",
  "tokio",
 ]
@@ -793,16 +792,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,6 +943,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,7 @@ hickory-proto = "0.24.1"
 hickory-client = "0.24.1"
 anyhow = "1.0.86"
 futures-util = { version = "0.3.30", default-features = false }
-signal-hook = "0.3.17"
-tokio = { version = "1.39.0", features = ["macros", "rt-multi-thread", "net"] }
+tokio = { version = "1.39.0", features = ["macros", "rt-multi-thread", "net", "signal"] }
 resolv-conf = "0.7.0"
 nix = { version = "0.29.0", features = ["fs", "signal"] }
 libc = "0.2.154"

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -216,8 +216,17 @@ async fn stop_threads<Ip>(
     }
 
     for handle in handles {
-        if let Err(e) = handle.await {
-            error!("Error from dns server: {:?}", e);
+        match handle.await {
+            Ok(res) => {
+                // result returned by the future, i.e. that actual
+                // result from start_dns_server()
+                if let Err(e) = res {
+                    // special anyhow error format to include cause but do not print backtrace
+                    error!("Error from dns server: {:#}", e)
+                }
+            }
+            // error from tokio itself
+            Err(e) => error!("Error from dns server task: {}", e),
         }
     }
 }


### PR DESCRIPTION
The code currently doesn't check for most child errors as it basicaly
immediately wrote the ready byte. Also it never considered the fact that
the child can exit early and in that case it would have blocked forever
because the parent never closed the writing side before call read().

This fixes that part, however it still reports success way to early. It
should wait for the first bind but that needs more complicated changes.


serve: fix broken error logging

Turns out the task contains a result in a result and we were only
looking at task error caused by tokio and not the actual result returned
from start_dns_server().
This caused all bind error to go nowhere and no even logged by in the
journal.

Fixes: https://github.com/containers/aardvark-dns/commit/224756d98986355d7f7d71d79c8012f0c7e4c29d ("server: use only one tokio runtime")

---
Note  I still have to do more changes in order to get the bind error back to netavark on first start.
