### PR TITLE
config: ignore enoent errors while reading configs

### DIFF
--- a/src/test/test.rs
+++ b/src/test/test.rs
@@ -55,12 +55,9 @@ mod tests {
         }
     }
     #[test]
-    // Parse bad config files must fail
+    // Parse bad config files should not hard error
     fn test_parsing_bad_config_files() {
-        match parse_configs("src/test/config/podman_bad_config") {
-            Ok((_, _, _)) => panic!("parsing bad config must fail"),
-            Err(_) => {}
-        }
+        parse_configs("src/test/config/podman_bad_config").expect("config parsing failed");
     }
     /* -------------------------------------------- */
     // -------Verify backend custom dns server ----


### PR DESCRIPTION
When we list files in directory there is a race where the file might have been removed in the meantime. So ignore the ENOENT case as this is no real error and we still want to parse the other files.