### PR TITLE
Change av cargo categories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 description = "A container-focused DNS server"
 homepage = "https://github.com/containers/aardvark-dns"
 repository = "https://github.com/containers/aardvark-dns"
-categories = ["containers", "networking", "dns", "podman"]
+categories = ["virtualization"]
 exclude = ["/.cirrus.yml", "/.github/*"]
 
 [package.metadata.vendor-filter]


### PR DESCRIPTION
To publish our crate, we must use official categories.  In this case, "virtualization" specifically calls out containers and seems appropriate.

Upstream: https://github.com/rust-lang/crates.io/pull/8930