### PR TITLE
[skip-ci] Packit: add sidetag to release with netavark

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -146,13 +146,8 @@ jobs:
 
   - job: koji_build
     trigger: commit
+    sidetag_group: netavark-releases
+    dependents:
+      - netavark
     dist_git_branches:
       - fedora-all
-
-        # NOTE: Bodhi update tasks are disabled to allow netavark and aardvark-dns X.Y
-        # builds in a single manual bodhi update. Leaving this commented out
-        # but not deleted so it's not forgotten.
-        #- job: bodhi_update
-        #trigger: commit
-        #dist_git_branches:
-        #- fedora-branched # rawhide updates are created automatically


### PR DESCRIPTION
Packit now supports Fedora sidetags to ship multiple package updates in a single bodhi.
Ref: https://packit.dev/docs/fedora-releases-guide/releasing-multiple-packages

With sidetag enablement, the packit bodhi update job is only needed in
one package. In this case, we can keep the bodhi job in netavark.
Ref: https://github.com/containers/netavark/pull/1071
