### PR TITLE
[skip-ci] TMT: Downstream-specific: install builddeps before test runs

### DIFF
--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -15,6 +15,7 @@ execute:
     summary: Run tests on bodhi / errata and dist-git PRs
     discover+:
         filter: tag:downstream
+        dist-git-install-builddeps: true
         dist-git-source: true
         dist-git-remove-fmf-root: true
     adjust+:


### PR DESCRIPTION
TMT tries to run `rpmbuild -bp` before triggering tests and it fails if builddeps are not installed prior.
Ref: https://artifacts.dev.testing-farm.io/6c690b69-5ef6-45b8-975d-9fcc95ea078e/

This has been fixed in Fedora and should be propagated upstream. 
PR Ref: https://src.fedoraproject.org/rpms/aardvark-dns/pull-request/35
Bodhi Ref: https://bodhi.fedoraproject.org/updates/FEDORA-2024-eca8e4f443