### PR TITLE
netavark_cache_groom.sh: fix wrong branch

### DIFF
--- a/contrib/cirrus/netavark_cache_groom.sh
+++ b/contrib/cirrus/netavark_cache_groom.sh
@@ -11,13 +11,13 @@ set -eo pipefail
 SCRIPT_DIRPATH=$(dirname ${BASH_SOURCE[0]})
 source $SCRIPT_DIRPATH/lib.sh
 
-if [[ "$CIRRUS_CI" != true ]] || [[ -z "$DEST_BRANCH" ]]; then
+if [[ "$CIRRUS_CI" != true ]] || [[ -z "$NETAVARK_BRANCH" ]]; then
   die "Script is not intended for use outside of Cirrus-CI"
 fi
 
 SCRIPT_DEST=$SCRIPT_DIRPATH/cache_groom.sh
 showrun curl --location --silent --show-error -o $SCRIPT_DEST \
-  https://raw.githubusercontent.com/containers/netavark/$DEST_BRANCH/contrib/cirrus/cache_groom.sh
+  https://raw.githubusercontent.com/containers/netavark/$NETAVARK_BRANCH/contrib/cirrus/cache_groom.sh
 
 # Certain common automation library calls assume execution from this file
 exec bash $SCRIPT_DEST


### PR DESCRIPTION
As this download from the netavark repo is should use the NETAVARK_BRANCH env.

Porting from https://github.com/containers/aardvark-dns/pull/507, not failing on main as both branches are set to main here anyway but in case we have a asny branch setup in the future again we need this