### PR TITLE
coredns: allow host lookup of names

### DIFF
--- a/src/dns/coredns.rs
+++ b/src/dns/coredns.rs
@@ -456,26 +456,13 @@ fn reply_ip<'a>(
     src_address: SocketAddr,
     req: &'a mut Message,
 ) -> Option<&'a Message> {
-    let mut resolved_ip_list: Vec<IpAddr> = Vec::new();
     // attempt intra network resolution
-    match backend.lookup(&src_address.ip(), name) {
+    let resolved_ip_list = match backend.lookup(&src_address.ip(), network_name, name) {
         // If we go success from backend lookup
-        Some(ips) => {
-            resolved_ip_list = ips;
-        }
-        // For everything else assume the src_address was not in ip_mappings
-        None => {
-            debug!("No backend lookup found, try resolving in current resolvers entry");
-            if let Some(container_mappings) = backend.name_mappings.get(network_name) {
-                if let Some(ips) = container_mappings.get(name) {
-                    resolved_ip_list.clone_from(ips);
-                }
-            }
-        }
-    }
-    if resolved_ip_list.is_empty() {
-        return None;
-    }
+        Some(ips) => ips,
+        None => return None,
+    };
+
     if record_type == RecordType::A {
         for record_addr in resolved_ip_list {
             if let IpAddr::V4(ipv4) = record_addr {

--- a/src/dns/coredns.rs
+++ b/src/dns/coredns.rs
@@ -1,5 +1,4 @@
 use crate::backend::DNSBackend;
-use crate::backend::DNSResult;
 use crate::error::AardvarkResult;
 use arc_swap::ArcSwap;
 use arc_swap::Guard;
@@ -461,12 +460,11 @@ fn reply_ip<'a>(
     // attempt intra network resolution
     match backend.lookup(&src_address.ip(), name) {
         // If we go success from backend lookup
-        DNSResult::Success(_ip_vec) => {
-            debug!("Found backend lookup");
-            resolved_ip_list = _ip_vec;
+        Some(ips) => {
+            resolved_ip_list = ips;
         }
         // For everything else assume the src_address was not in ip_mappings
-        _ => {
+        None => {
             debug!("No backend lookup found, try resolving in current resolvers entry");
             if let Some(container_mappings) = backend.name_mappings.get(network_name) {
                 if let Some(ips) = container_mappings.get(name) {

--- a/src/test/test.rs
+++ b/src/test/test.rs
@@ -151,7 +151,7 @@ mod tests {
         let res = parse_configs("src/test/config/podman")
             .expect("parse config error")
             .0
-            .lookup(&IP_10_88_0_2, "condescendingnash");
+            .lookup(&IP_10_88_0_2, "", "condescendingnash");
         assert_eq!(res, Some(vec![IP_10_88_0_2]));
     }
     #[test]
@@ -165,7 +165,7 @@ mod tests {
         let res = parse_configs("src/test/config/podman")
             .expect("parse config error")
             .0
-            .lookup(&IP_10_88_0_2, "helloworld");
+            .lookup(&IP_10_88_0_2, "", "helloworld");
         assert_eq!(res, Some(vec![IP_10_88_0_5]));
     }
     #[test]
@@ -179,7 +179,7 @@ mod tests {
         let res = parse_configs("src/test/config/podman")
             .expect("parse config error")
             .0
-            .lookup(&IP_10_88_0_2, "HELLOWORLD");
+            .lookup(&IP_10_88_0_2, "", "HELLOWORLD");
         assert_eq!(res, Some(vec![IP_10_88_0_5]));
     }
     #[test]
@@ -189,7 +189,7 @@ mod tests {
         let res = parse_configs("src/test/config/podman")
             .expect("parse config error")
             .0
-            .lookup(&IP_10_88_0_2, "somebadquery");
+            .lookup(&IP_10_88_0_2, "", "somebadquery");
         assert_eq!(res, None);
     }
     #[test]
@@ -202,7 +202,7 @@ mod tests {
         let res = parse_configs("src/test/config/podman")
             .expect("parse config error")
             .0
-            .lookup(&IP_10_88_0_2, "trustingzhukovsky");
+            .lookup(&IP_10_88_0_2, "", "trustingzhukovsky");
         assert_eq!(res, Some(vec![IP_10_88_0_4]));
     }
     #[test]
@@ -215,7 +215,7 @@ mod tests {
         let res = parse_configs("src/test/config/podman")
             .expect("parse config error")
             .0
-            .lookup(&IP_10_88_0_2, "ctr1");
+            .lookup(&IP_10_88_0_2, "", "ctr1");
         assert_eq!(res, Some(vec![IP_10_88_0_4]));
     }
     #[test]
@@ -228,9 +228,9 @@ mod tests {
         assert!(conf.1.contains_key("podman_v6_entries"));
         assert!(!conf.2.contains_key("podman_v6_entries"));
 
-        let ips = conf.0.lookup(&IP_10_89_0_2, "test1");
+        let ips = conf.0.lookup(&IP_10_89_0_2, "", "test1");
         assert_eq!(ips, Some(vec![IP_10_89_0_2, IP_FDFD_733B_DC3_220B_2]));
-        let ips = conf.0.lookup(&IP_FDFD_733B_DC3_220B_2, "test1");
+        let ips = conf.0.lookup(&IP_FDFD_733B_DC3_220B_2, "", "test1");
         assert_eq!(ips, Some(vec![IP_10_89_0_2, IP_FDFD_733B_DC3_220B_2]));
     }
     #[test]
@@ -244,9 +244,9 @@ mod tests {
         assert!(conf.1.contains_key("podman_v6_entries"));
         assert!(!conf.2.contains_key("podman_v6_entries"));
 
-        let ips = conf.0.lookup(&IP_10_89_0_2, "test2");
+        let ips = conf.0.lookup(&IP_10_89_0_2, "", "test2");
         assert_eq!(ips, Some(vec![IP_10_89_0_3, IP_FDFD_733B_DC3_220B_3]));
-        let ips = conf.0.lookup(&IP_FDFD_733B_DC3_220B_2, "test2");
+        let ips = conf.0.lookup(&IP_FDFD_733B_DC3_220B_2, "", "test2");
         assert_eq!(ips, Some(vec![IP_10_89_0_3, IP_FDFD_733B_DC3_220B_3]));
     }
     #[test]
@@ -261,7 +261,7 @@ mod tests {
         assert!(conf.1.contains_key("podman_v6_entries"));
         assert!(!conf.2.contains_key("podman_v6_entries"));
 
-        let ips = conf.0.lookup(&IP_10_89_0_2, "88dde8a24897");
+        let ips = conf.0.lookup(&IP_10_89_0_2, "", "88dde8a24897");
         assert_eq!(ips, Some(vec![IP_10_89_0_3, IP_FDFD_733B_DC3_220B_3]));
     }
     /* -------------------------------------------- */
@@ -440,7 +440,7 @@ mod tests {
                         "fddd::1".parse().unwrap()
                     ]
                 );
-                match backend.lookup(&"10.0.0.2".parse().unwrap(), "testmulti1") {
+                match backend.lookup(&"10.0.0.2".parse().unwrap(), "", "testmulti1") {
                     Some(ip_vec) => {
                         assert_eq!(
                             ip_vec,
@@ -455,7 +455,7 @@ mod tests {
                     _ => panic!("unexpected dns result"),
                 }
 
-                match backend.lookup(&"10.0.0.2".parse().unwrap(), "testmulti2") {
+                match backend.lookup(&"10.0.0.2".parse().unwrap(), "", "testmulti2") {
                     Some(ip_vec) => {
                         assert_eq!(
                             ip_vec,

--- a/src/test/test.rs
+++ b/src/test/test.rs
@@ -8,10 +8,24 @@ mod tests {
     use std::collections::HashMap;
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-    use aardvark_dns::backend::{DNSBackend, DNSResult};
+    use aardvark_dns::backend::DNSBackend;
     use aardvark_dns::config;
     use aardvark_dns::error::AardvarkResult;
     use std::str::FromStr;
+
+    const IP_10_88_0_2: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 88, 0, 2));
+    const IP_10_88_0_4: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 88, 0, 4));
+    const IP_10_88_0_5: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 88, 0, 5));
+
+    const IP_10_89_0_2: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 89, 0, 2));
+    const IP_10_89_0_3: IpAddr = IpAddr::V4(Ipv4Addr::new(10, 89, 0, 3));
+
+    /// fdfd:733b:dc3:220b::2
+    const IP_FDFD_733B_DC3_220B_2: IpAddr =
+        IpAddr::V6(Ipv6Addr::new(0xfdfd, 0x733b, 0xdc3, 0x220b, 0, 0, 0, 2));
+    /// fdfd:733b:dc3:220b::3
+    const IP_FDFD_733B_DC3_220B_3: IpAddr =
+        IpAddr::V6(Ipv6Addr::new(0xfdfd, 0x733b, 0xdc3, 0x220b, 0, 0, 0, 3));
 
     fn parse_configs(
         dir: &str,
@@ -134,18 +148,11 @@ mod tests {
     // Request address must be v4.
     // Same container --> (resolve) Same container name --> (on) Same Network
     fn test_lookup_queries_from_backend_simulate_same_container_request_from_v4_on_v4_entries() {
-        match parse_configs("src/test/config/podman") {
-            Ok((backend, _, _)) => {
-                match backend.lookup(&"10.88.0.2".parse().unwrap(), "condescendingnash") {
-                    DNSResult::Success(ip_vec) => {
-                        assert_eq!(ip_vec.len(), 1);
-                        assert_eq!("10.88.0.2".parse(), Ok(ip_vec[0]));
-                    }
-                    _ => panic!("unexpected dns result"),
-                }
-            }
-            Err(e) => panic!("{}", e),
-        }
+        let res = parse_configs("src/test/config/podman")
+            .expect("parse config error")
+            .0
+            .lookup(&IP_10_88_0_2, "condescendingnash");
+        assert_eq!(res, Some(vec![IP_10_88_0_2]));
     }
     #[test]
     // Check lookup query from backend and simulate
@@ -155,18 +162,11 @@ mod tests {
     // Same container --> (resolve) Same container name --> (on) Same Network
     fn test_lookup_queries_from_backend_simulate_same_container_request_from_v4_on_v4_entries_case_insensitive(
     ) {
-        match parse_configs("src/test/config/podman") {
-            Ok((backend, _, _)) => {
-                match backend.lookup(&"10.88.0.2".parse().unwrap(), "helloworld") {
-                    DNSResult::Success(ip_vec) => {
-                        assert_eq!(ip_vec.len(), 1);
-                        assert_eq!("10.88.0.5".parse(), Ok(ip_vec[0]));
-                    }
-                    _ => panic!("unexpected dns result"),
-                }
-            }
-            Err(e) => panic!("{}", e),
-        }
+        let res = parse_configs("src/test/config/podman")
+            .expect("parse config error")
+            .0
+            .lookup(&IP_10_88_0_2, "helloworld");
+        assert_eq!(res, Some(vec![IP_10_88_0_5]));
     }
     #[test]
     // Check lookup query from backend and simulate
@@ -176,32 +176,21 @@ mod tests {
     // Same container --> (resolve) Same container name --> (on) Same Network
     fn test_lookup_queries_from_backend_simulate_same_container_request_from_v4_on_v4_entries_case_insensitive_uppercase(
     ) {
-        match parse_configs("src/test/config/podman") {
-            Ok((backend, _, _)) => {
-                match backend.lookup(&"10.88.0.2".parse().unwrap(), "HELLOWORLD") {
-                    DNSResult::Success(ip_vec) => {
-                        assert_eq!(ip_vec.len(), 1);
-                        assert_eq!("10.88.0.5".parse(), Ok(ip_vec[0]));
-                    }
-                    _ => panic!("unexpected dns result"),
-                }
-            }
-            Err(e) => panic!("{}", e),
-        }
+        let res = parse_configs("src/test/config/podman")
+            .expect("parse config error")
+            .0
+            .lookup(&IP_10_88_0_2, "HELLOWORLD");
+        assert_eq!(res, Some(vec![IP_10_88_0_5]));
     }
     #[test]
     // Check lookup query from backend and simulate
     // nx_domain on bad lookup queries.
     fn test_lookup_queries_from_backend_simulate_nx_domain() {
-        match parse_configs("src/test/config/podman") {
-            Ok((backend, _, _)) => {
-                match backend.lookup(&"10.88.0.2".parse().unwrap(), "somebadquery") {
-                    DNSResult::NXDomain => {}
-                    _ => panic!("unexpected dns result"),
-                }
-            }
-            Err(e) => panic!("{}", e),
-        }
+        let res = parse_configs("src/test/config/podman")
+            .expect("parse config error")
+            .0
+            .lookup(&IP_10_88_0_2, "somebadquery");
+        assert_eq!(res, None);
     }
     #[test]
     // Check lookup query from backend and simulate
@@ -210,18 +199,11 @@ mod tests {
     // Request address must be v4.
     // Same container --> (resolve) different container name --> (on) Same Network
     fn test_lookup_queries_from_backend_simulate_different_container_request_from_v4() {
-        match parse_configs("src/test/config/podman") {
-            Ok((backend, _, _)) => {
-                match backend.lookup(&"10.88.0.2".parse().unwrap(), "trustingzhukovsky") {
-                    DNSResult::Success(ip_vec) => {
-                        assert_eq!(ip_vec.len(), 1);
-                        assert_eq!("10.88.0.4".parse(), Ok(ip_vec[0]));
-                    }
-                    _ => panic!("unexpected dns result"),
-                }
-            }
-            Err(e) => panic!("{}", e),
-        }
+        let res = parse_configs("src/test/config/podman")
+            .expect("parse config error")
+            .0
+            .lookup(&IP_10_88_0_2, "trustingzhukovsky");
+        assert_eq!(res, Some(vec![IP_10_88_0_4]));
     }
     #[test]
     // Check lookup query from backend and simulate
@@ -230,117 +212,42 @@ mod tests {
     // Request address must be v4.
     // Same container --> (resolve) different container name by alias --> (on) Same Network
     fn test_lookup_queries_from_backend_simulate_different_container_request_from_v4_by_alias() {
-        match parse_configs("src/test/config/podman") {
-            Ok((backend, _, _)) => match backend.lookup(&"10.88.0.2".parse().unwrap(), "ctr1") {
-                DNSResult::Success(ip_vec) => {
-                    // verfiy length for issues like: https://github.com/containers/aardvark-dns/issues/120
-                    assert_eq!(ip_vec.len(), 1);
-                    assert_eq!("10.88.0.4".parse(), Ok(ip_vec[0]));
-                }
-                _ => panic!("unexpected dns result"),
-            },
-            Err(e) => panic!("{}", e),
-        }
+        let res = parse_configs("src/test/config/podman")
+            .expect("parse config error")
+            .0
+            .lookup(&IP_10_88_0_2, "ctr1");
+        assert_eq!(res, Some(vec![IP_10_88_0_4]));
     }
     #[test]
     // Check lookup query from backend and simulate
     // dns request from same container to itself but
     // aardvark must return two ip address for v4 and v6.
-    // Request address must be v4.
     // Same container --> (resolve) Same container name --> (on) Same Network
-    fn test_lookup_queries_from_backend_simulate_same_container_request_from_v4_on_v6_and_v4_entries(
-    ) {
-        match parse_configs("src/test/config/podman_v6_entries") {
-            Ok((backend, listen_ip_v4, listen_ip_v6)) => {
-                listen_ip_v6.contains_key("podman_v6_entries");
-                listen_ip_v4.contains_key("podman_v6_entries");
-                match backend.lookup(&"10.89.0.2".parse().unwrap(), "test1") {
-                    DNSResult::Success(ip_vec) => {
-                        // verfiy length for issues like: https://github.com/containers/aardvark-dns/issues/120
-                        assert_eq!(ip_vec.len(), 2);
-                        assert_eq!("10.89.0.2".parse(), Ok(ip_vec[0]));
-                        assert_eq!("fdfd:733b:dc3:220b::2".parse(), Ok(ip_vec[1]));
-                    }
-                    _ => panic!("unexpected dns result"),
-                }
-            }
-            Err(e) => panic!("{}", e),
-        }
-    }
-    #[test]
-    // Check lookup query from backend and simulate
-    // dns request from same container to itself but
-    // aardvark must return two ip address for v4 and v6.
-    // Request address must be v6.
-    // Same container --> (resolve) Same container name --> (on) Same Network
-    fn test_lookup_queries_from_backend_simulate_same_container_request_from_v6_on_v6_and_v4_entries(
-    ) {
-        match parse_configs("src/test/config/podman_v6_entries") {
-            Ok((backend, listen_ip_v4, listen_ip_v6)) => {
-                listen_ip_v6.contains_key("podman_v6_entries");
-                listen_ip_v4.contains_key("podman_v6_entries");
-                match backend.lookup(&"fdfd:733b:dc3:220b::2".parse().unwrap(), "test1") {
-                    DNSResult::Success(ip_vec) => {
-                        // verfiy length for issues like: https://github.com/containers/aardvark-dns/issues/120
-                        assert_eq!(ip_vec.len(), 2);
-                        assert_eq!("10.89.0.2".parse(), Ok(ip_vec[0]));
-                        assert_eq!("fdfd:733b:dc3:220b::2".parse(), Ok(ip_vec[1]));
-                    }
-                    _ => panic!("unexpected dns result"),
-                }
-            }
-            Err(e) => panic!("{}", e),
-        }
+    fn test_lookup_queries_from_backend_simulate_same_container_request_from_v4_and_v6_entries() {
+        let conf = parse_configs("src/test/config/podman_v6_entries").expect("parse config error");
+        assert!(conf.1.contains_key("podman_v6_entries"));
+        assert!(!conf.2.contains_key("podman_v6_entries"));
+
+        let ips = conf.0.lookup(&IP_10_89_0_2, "test1");
+        assert_eq!(ips, Some(vec![IP_10_89_0_2, IP_FDFD_733B_DC3_220B_2]));
+        let ips = conf.0.lookup(&IP_FDFD_733B_DC3_220B_2, "test1");
+        assert_eq!(ips, Some(vec![IP_10_89_0_2, IP_FDFD_733B_DC3_220B_2]));
     }
     #[test]
     // Check lookup query from backend and simulate
     // dns request from container to another container but
     // aardvark must return two ip address for v4 and v6.
-    // Request address must be v6.
     // Same container --> (resolve) different container name --> (on) Same Network
-    fn test_lookup_queries_from_backend_simulate_different_container_request_from_v6_on_v6_and_v4_entries(
+    fn test_lookup_queries_from_backend_simulate_different_container_request_from_v4_and_v6_entries(
     ) {
-        match parse_configs("src/test/config/podman_v6_entries") {
-            Ok((backend, listen_ip_v4, listen_ip_v6)) => {
-                listen_ip_v6.contains_key("podman_v6_entries");
-                listen_ip_v4.contains_key("podman_v6_entries");
-                match backend.lookup(&"fdfd:733b:dc3:220b::2".parse().unwrap(), "test2") {
-                    DNSResult::Success(ip_vec) => {
-                        // verfiy length for issues like: https://github.com/containers/aardvark-dns/issues/120
-                        assert_eq!(ip_vec.len(), 2);
-                        assert_eq!("10.89.0.3".parse(), Ok(ip_vec[0]));
-                        assert_eq!("fdfd:733b:dc3:220b::3".parse(), Ok(ip_vec[1]));
-                    }
-                    _ => panic!("unexpected dns result"),
-                }
-            }
-            Err(e) => panic!("{}", e),
-        }
-    }
-    #[test]
-    // Check lookup query from backend and simulate
-    // dns request from container to another container but
-    // aardvark must return two ip address for v4 and v6.
-    // Request address must be v6.
-    // Same container --> (resolve) different container name --> (on) Same Network
-    fn test_lookup_queries_from_backend_simulate_different_container_request_from_v4_on_v6_and_v4_entries(
-    ) {
-        match parse_configs("src/test/config/podman_v6_entries") {
-            Ok((backend, listen_ip_v4, listen_ip_v6)) => {
-                listen_ip_v6.contains_key("podman_v6_entries");
-                listen_ip_v4.contains_key("podman_v6_entries");
-                match backend.lookup(&"10.89.0.2".parse().unwrap(), "test2") {
-                    DNSResult::Success(ip_vec) => {
-                        // verfiy length for issues like: https://github.com/containers/aardvark-dns/issues/120
-                        assert_eq!(ip_vec.len(), 2);
-                        assert_eq!("10.89.0.3".parse(), Ok(ip_vec[0]));
-                        assert_eq!("fdfd:733b:dc3:220b::3".parse(), Ok(ip_vec[1]));
-                    }
-                    _ => panic!("unexpected dns result"),
-                }
-            }
-            Err(e) => panic!("{}", e),
-        }
+        let conf = parse_configs("src/test/config/podman_v6_entries").expect("parse config error");
+        assert!(conf.1.contains_key("podman_v6_entries"));
+        assert!(!conf.2.contains_key("podman_v6_entries"));
+
+        let ips = conf.0.lookup(&IP_10_89_0_2, "test2");
+        assert_eq!(ips, Some(vec![IP_10_89_0_3, IP_FDFD_733B_DC3_220B_3]));
+        let ips = conf.0.lookup(&IP_FDFD_733B_DC3_220B_2, "test2");
+        assert_eq!(ips, Some(vec![IP_10_89_0_3, IP_FDFD_733B_DC3_220B_3]));
     }
     #[test]
     // Check lookup query from backend and simulate
@@ -350,22 +257,12 @@ mod tests {
     // Same container --> (resolve) different container by id --> (on) Same Network
     fn test_lookup_queries_from_backend_simulate_different_container_request_by_id_from_v4_on_v6_and_v4_entries(
     ) {
-        match parse_configs("src/test/config/podman_v6_entries") {
-            Ok((backend, listen_ip_v4, listen_ip_v6)) => {
-                listen_ip_v6.contains_key("podman_v6_entries");
-                listen_ip_v4.contains_key("podman_v6_entries");
-                match backend.lookup(&"10.89.0.2".parse().unwrap(), "88dde8a24897") {
-                    DNSResult::Success(ip_vec) => {
-                        // verfiy length for issues like: https://github.com/containers/aardvark-dns/issues/120
-                        assert_eq!(ip_vec.len(), 2);
-                        assert_eq!("10.89.0.3".parse(), Ok(ip_vec[0]));
-                        assert_eq!("fdfd:733b:dc3:220b::3".parse(), Ok(ip_vec[1]));
-                    }
-                    _ => panic!("unexpected dns result"),
-                }
-            }
-            Err(e) => panic!("{}", e),
-        }
+        let conf = parse_configs("src/test/config/podman_v6_entries").expect("parse config error");
+        assert!(conf.1.contains_key("podman_v6_entries"));
+        assert!(!conf.2.contains_key("podman_v6_entries"));
+
+        let ips = conf.0.lookup(&IP_10_89_0_2, "88dde8a24897");
+        assert_eq!(ips, Some(vec![IP_10_89_0_3, IP_FDFD_733B_DC3_220B_3]));
     }
     /* -------------------------------------------- */
     // ---Test aardvark-dns reverse lookup logic --
@@ -544,7 +441,7 @@ mod tests {
                     ]
                 );
                 match backend.lookup(&"10.0.0.2".parse().unwrap(), "testmulti1") {
-                    DNSResult::Success(ip_vec) => {
+                    Some(ip_vec) => {
                         assert_eq!(
                             ip_vec,
                             vec![
@@ -559,7 +456,7 @@ mod tests {
                 }
 
                 match backend.lookup(&"10.0.0.2".parse().unwrap(), "testmulti2") {
-                    DNSResult::Success(ip_vec) => {
+                    Some(ip_vec) => {
                         assert_eq!(
                             ip_vec,
                             vec![

--- a/test/200-two-networks.bats
+++ b/test/200-two-networks.bats
@@ -48,6 +48,17 @@ load helpers
 	# b1 should be able to resolve itself
 	dig "$b1_pid" "bone" "$b_gw"
 	assert $b1_ip
+
+	# we should be able to resolve a from the host if we use the a gw as server
+	run_in_host_netns dig +short "aone" "@$a_gw"
+	assert $a1_ip
+	#  but NOT when using b as server
+	expected_rc=1 run_in_host_netns "host" "-t" "ns" "aone" "$b_gw"
+	assert "$output" =~ "Host aone not found"
+	assert "$output" =~ "NXDOMAIN"
+	# but b on network b is allowed again
+	run_in_host_netns dig +short "bone" "@$b_gw"
+	assert $b1_ip
 }
 
 @test "two subnets with isolated container and one shared" {


### PR DESCRIPTION


In my rework it seems I broke the weird way how we tried to resolve
names when we have no source ip match. Let's do this properly and move
the logic all into lookup() which makes it much cleaner and no
duplication needed.

Now there is catch here, we only lookup the network for the current
network listener, so if the user has multiple networks they always must
target the requests against the correct ip depeding on what network the
name is in. But this is the same as it worked before and seems safer
than allowing a unknown ip to access all names I guess.

Fixes https://github.com/containers/aardvark-dns/issues/508