### PR TITLE
Release v1.10.1-rhel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aardvark-dns"
-version = "1.10.0"
+version = "1.10.1-rhel"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aardvark-dns"
 # This version specification right below is reused by .packit.sh to generate rpm version
-version = "1.10.0"
+version = "1.10.1-rhel"
 edition = "2018"
 authors = ["github.com/containers"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 description = "A container-focused DNS server"
 homepage = "https://github.com/containers/aardvark-dns"
 repository = "https://github.com/containers/aardvark-dns"
-categories = ["containers", "networking", "dns", "podman"]
+categories = ["virtualization"]
 exclude = ["/.cirrus.yml", "/.github/*"]
 
 [package.metadata.vendor-filter]


### PR DESCRIPTION

New rhel release for
https://issues.redhat.com/browse/RHEL-59129
https://issues.redhat.com/browse/ACCELFIX-287

Also fix the cargo categories in case we want to push to crates.io.
