### PR TITLE
serve: parse resolv.conf ourselves

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,6 @@ dependencies = [
  "libc",
  "log",
  "nix",
- "resolv-conf",
  "syslog",
  "tokio",
 ]
@@ -684,12 +683,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,15 +729,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "resolv-conf"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
-dependencies = [
- "quick-error",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ hickory-proto = { version = "0.24.1", features = ["tokio-runtime"] }
 hickory-client = "0.24.1"
 futures-util = { version = "0.3.30", default-features = false }
 tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread", "net", "signal"] }
-resolv-conf = "0.7.0"
 nix = { version = "0.29.0", features = ["fs", "signal"] }
 libc = "0.2.159"
 arc-swap = "1.7.1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,7 @@ pub enum AardvarkError {
     IOError(std::io::Error),
     Chain(String, Box<Self>),
     List(AardvarkErrorList),
-    ResolvConfParseError(resolv_conf::ParseError),
+    AddrParseError(std::net::AddrParseError),
 }
 
 impl AardvarkError {
@@ -59,7 +59,7 @@ impl fmt::Display for AardvarkError {
             Self::Message(s) => write!(f, "{s}"),
             Self::Chain(s, e) => write!(f, "{s}: {e}"),
             Self::IOError(e) => write!(f, "IO error: {e}"),
-            Self::ResolvConfParseError(e) => write!(f, "parse resolv.conf: {e}"),
+            Self::AddrParseError(e) => write!(f, "parse address: {e}"),
             Self::List(list) => {
                 // some extra code to only add \n when it contains multiple errors
                 let mut iter = list.0.iter();
@@ -87,9 +87,9 @@ impl From<nix::Error> for AardvarkError {
     }
 }
 
-impl From<resolv_conf::ParseError> for AardvarkError {
-    fn from(err: resolv_conf::ParseError) -> Self {
-        Self::ResolvConfParseError(err)
+impl From<std::net::AddrParseError> for AardvarkError {
+    fn from(err: std::net::AddrParseError) -> Self {
+        Self::AddrParseError(err)
     }
 }
 


### PR DESCRIPTION
The resolv.conf parsing lib is super strict and does not allow unknown options, given we do not care about options search domains or really anything else in this file parse it ourselves with very lax rules.

Basically we try to find the nameserver lines. Anything else is ignored, the only error we produce is if we fail to parse the nameserver ip address.

Fixes #418
Fixes https://issues.redhat.com/browse/RHEL-57695