### PR TITLE
test: make them pass on RHEL/Centos Stream 9

### DIFF
--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -385,7 +385,7 @@ fn parse_resolv_conf(content: &str) -> AardvarkResult<Vec<IpAddr>> {
     let mut nameservers: Vec<IpAddr> = Vec::new();
     for line in content.split('\n') {
         // split of comments
-        let line = match line.split_once(|s| s == '#' || s == ';') {
+        let line = match line.split_once(['#', ';']) {
             Some((f, _)) => f,
             None => line,
         };

--- a/test/100-basic-name-resolution.bats
+++ b/test/100-basic-name-resolution.bats
@@ -89,7 +89,9 @@ load helpers
 	run_in_container_netns "$a1_pid" "dig" "+tcp" "google.com" "@$gw"
 	# validate that we get an ipv4
 	assert "$output" =~ "[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+"
-	assert "$output" =~ "\(TCP\)" "server used TCP"
+	# TODO This is not working on rhel/centos 9 as the dig version there doesn't print the line,
+	# so we trust that dig +tcp does the right thing.
+	# assert "$output" =~ "\(TCP\)" "server used TCP"
 	# Set recursion bit is already set if requested so output must not
 	# contain unexpected warning.
 	assert "$output" !~ "WARNING: recursion requested but not available"


### PR DESCRIPTION
The dig version there doesn't print the protocol in the output and it is not really that important to check as we assume that dig +tcp does the right thing anyway.