### PR TITLE
[skip-ci] Packit: constrain koji job to the fedora package

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -157,6 +157,7 @@ jobs:
 
   - job: koji_build
     trigger: commit
+    packages: [aardvark-dns-fedora]
     sidetag_group: netavark-releases
     dependents:
       - netavark


### PR DESCRIPTION
This helps to avoid dup downstream jobs. Doesn't affect upstream.