### PR TITLE
coredns: forward names with no ndots as well

### DIFF
--- a/src/dns/coredns.rs
+++ b/src/dns/coredns.rs
@@ -202,7 +202,6 @@ impl CoreDns {
         if data.no_proxy
             || backend.ctr_is_internal(&src_address.ip())
             || request_name_string.ends_with(&backend.search_domain)
-            || request_name_string.matches('.').count() == 1
         {
             let mut nx_message = req.clone();
             nx_message.set_response_code(ResponseCode::NXDomain);

--- a/test/300-three-networks.bats
+++ b/test/300-three-networks.bats
@@ -6,6 +6,8 @@
 load helpers
 
 @test "three networks with a connect" {
+	setup_dnsmasq
+
 	subnet_a=$(random_subnet 5)
 	subnet_b=$(random_subnet 5)
 

--- a/test/dnsmasq.conf
+++ b/test/dnsmasq.conf
@@ -1,0 +1,19 @@
+interface=lo
+bind-interfaces
+
+no-hosts
+no-resolv
+
+log-queries
+
+user=
+
+# aone and bone should return NXDOMAIN, by default dnsmasq returns REFUSED
+address=/aone/
+address=/bone/
+address=/testname/198.51.100.1
+address=/testname.local/198.51.100.2
+address=/example.podman.io/198.51.100.100
+
+
+txt-record=example.podman.io,"v=spf1 a -all"


### PR DESCRIPTION
Docker does this and there might be local names and a local resolver that otherwise cannot be resolved.

Fixes https://issues.redhat.com/browse/RHEL-61873