### PR TITLE
Release v1.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aardvark-dns"
-version = "1.13.0-dev"
+version = "1.13.0"
 dependencies = [
  "arc-swap",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aardvark-dns"
-version = "1.13.0"
+version = "1.14.0-dev"
 dependencies = [
  "arc-swap",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aardvark-dns"
 # This version specification right below is reused by .packit.sh to generate rpm version
-version = "1.13.0"
+version = "1.14.0-dev"
 edition = "2018"
 authors = ["github.com/containers"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aardvark-dns"
 # This version specification right below is reused by .packit.sh to generate rpm version
-version = "1.13.0-dev"
+version = "1.13.0"
 edition = "2018"
 authors = ["github.com/containers"]
 license = "Apache-2.0"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## v1.13.0
+
+* Set TTL to 0 for container names
+* Allow forwarding of names with no ndots
+* DNS: limit to 3 resolvers and use better timeout for them
+* Ignore unknown resolv.conf options
+
+## v1.12.2
+
+* This releases fixes a security issue (CVE-2024-8418) where tcp connections where not handled correctly which allowed a container to block dns queries for other clients on the same network #500. Versions before v1.12.0 are unaffected as they do not have tcp support.
+
 ## v1.12.1
 
 * Fixed problem with categories in Cargo.toml that prevented us from publishing v1.12.0


### PR DESCRIPTION
* Set TTL to 0 for container names
* Allow forwarding of names with no ndots
* DNS: limit to 3 resolvers and use better timeout for them
* Ignore unknown resolv.conf options
