### PR TITLE
[skip-ci] Packit / TMT / rpm update (see individual commits)

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -135,6 +135,7 @@ jobs:
     update_release: false
     dist_git_branches:
       - c10s
+      - c9s
 
   - job: koji_build
     trigger: commit

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -47,6 +47,7 @@ jobs:
       - fedora-all-x86_64
       - fedora-all-aarch64
     enable_net: true
+    osh_diff_scan_after_copr_build: false
 
   - job: copr_build
     trigger: pull_request

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -15,6 +15,7 @@ execute:
     summary: Run tests on bodhi / errata and dist-git PRs
     discover+:
         filter: tag:downstream
+        dist-git-install-builddeps: true
         dist-git-source: true
         dist-git-remove-fmf-root: true
     adjust+:

--- a/rpm/aardvark-dns.spec
+++ b/rpm/aardvark-dns.spec
@@ -88,12 +88,4 @@ tar fx %{SOURCE1}
 %{_libexecdir}/podman/%{name}
 
 %changelog
-%if %{defined autochangelog}
 %autochangelog
-%else
-# NOTE: This changelog will be visible on CentOS 8 Stream builds
-# Other envs are capable of handling autochangelog
-* Wed Jun 14 2023 RH Container Bot <rhcontainerbot@fedoraproject.org>
-- Placeholder changelog for envs that are not autochangelog-ready
-- Contact upstream if you need to report an issue with the build.
-%endif


### PR DESCRIPTION
This PR:
1. enables c9s downstream update via packit
2. cleans up changelog conditionals from rpm spec
3. installs builddeps in downstream testing-farm environments (needed to run rpmbuild -bp).