### PR TITLE
support ipv6 link local addresses in resolv.conf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,6 +553,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,6 +610,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ hickory-proto = { version = "0.24.1", features = ["tokio-runtime"] }
 hickory-client = "0.24.1"
 futures-util = { version = "0.3.31", default-features = false }
 tokio = { version = "1.41.0", features = ["macros", "rt-multi-thread", "net", "signal"] }
-nix = { version = "0.29.0", features = ["fs", "signal"] }
+nix = { version = "0.29.0", features = ["fs", "signal", "net"] }
 libc = "0.2.161"
 arc-swap = "1.7.1"
 flume = "0.11.1"


### PR DESCRIPTION
The recent change to move parsing resolv.conf into our code caused a regression with link local addresses. We did not split "%" correctly due a typo. While the fix for that is simple ignoring the zone part as we did before will not work as the zone must be given for link local addresses.

And as it turns out it does not need much changes to actually support the zone part properly. We can just pass the SocketAddr type around. The only problem there is that we must know the numeric id and not the interface name in the struct. To resolve name -> id we can simply call if_nametoindex that is provided by libc which is safely wrapped in the nix crate.

Fixes 22293ef ("serve: parse resolv.conf ourselves")
Fixes #535