### PR TITLE
test: make jq query work on centos stream 9

### DIFF
--- a/test/100-basic-name-resolution.bats
+++ b/test/100-basic-name-resolution.bats
@@ -288,7 +288,7 @@ function teardown() {
 	run_in_host_netns ip link add test type bridge
 	run_in_host_netns ip link set test up
 	run_in_host_netns ip -j addr
-	link_local_addr=$(jq -r '.[] | select(.ifname=="test").addr_info.[0].local' <<<"$output")
+	link_local_addr=$(jq -r '.[] | select(.ifname=="test").addr_info[0].local' <<<"$output")
 
 	# update our fake netns resolv.conf with the link local address as only nameserver
 	echo "nameserver $link_local_addr%test" >"$AARDVARK_TMPDIR/resolv.conf"


### PR DESCRIPTION
The syntax is not accepted by older version like on centos stream 9, this one should work with all versions and thus make the tmt tests on centos 9 stream pass again.