### PR TITLE
[skip-ci] RPM/TMT: use tests subpackage

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -16,6 +16,11 @@ files_to_sync:
   - src: plans/
     dest: plans/
     delete: true
+    mkpath: true
+  - src: test/tmt
+    dest: test/tmt
+    delete: true
+    mkpath: true
   - src: .fmf/
     dest: .fmf/
     delete: true
@@ -43,7 +48,7 @@ jobs:
     notifications: &copr_build_failure_notification
       failure_comment:
         message: "Ephemeral COPR build failed. @containers/packit-build please check."
-    targets:
+    targets: &fedora_copr_targets
       - fedora-all-x86_64
       - fedora-all-aarch64
     enable_net: true
@@ -85,29 +90,21 @@ jobs:
     project: podman-next
     enable_net: true
 
-  # Unit tests on Fedora
+  # Tests on Fedora
   - job: tests
     trigger: pull_request
     packages: [aardvark-dns-fedora]
     notifications: &test_failure_notification
       failure_comment:
         message: "Tests failed. @containers/packit-build please check."
-    targets:
-      - fedora-development-x86_64
-      - fedora-development-aarch64
-      - fedora-latest-x86_64
-      - fedora-latest-aarch64
-      - fedora-latest-stable-x86_64
-      - fedora-latest-stable-aarch64
-      - fedora-40-x86_64
-      - fedora-40-aarch64
+    targets: *fedora_copr_targets
     tf_extra_params:
       environments:
         - artifacts:
           - type: repository-file
             id: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/repo/fedora-$releasever/rhcontainerbot-podman-next-fedora-$releasever.repo
 
-  # Unit tests on CentOS Stream
+  # Tests on CentOS Stream
   - job: tests
     trigger: pull_request
     packages: [aardvark-dns-centos]
@@ -118,8 +115,6 @@ jobs:
         - artifacts:
           - type: repository-file
             id: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/repo/centos-stream-$releasever/rhcontainerbot-podman-next-centos-stream-$releasever.repo
-          - type: repository-file
-            id: https://src.fedoraproject.org/rpms/epel-release/raw/epel$releasever/f/epel.repo
 
   # Sync to Fedora
   - job: propose_downstream

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -2,22 +2,32 @@ discover:
     how: fmf
 execute:
     how: tmt
+prepare:
+    - when: distro == centos-stream or distro == rhel
+      how: shell
+      script: |
+        dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(rpm --eval '%{?rhel}').noarch.rpm
+        dnf -y config-manager --set-enabled epel
+      order: 10
+    - when: initiator == packit
+      how: shell
+      script: |
+        COPR_REPO_FILE="/etc/yum.repos.d/*podman-next*.repo"
+        if compgen -G $COPR_REPO_FILE > /dev/null; then
+            sed -i -n '/^priority=/!p;$apriority=1' $COPR_REPO_FILE
+        fi
+        dnf -y upgrade --allowerasing
+      order: 20
 
-/upstream:
-    summary: Run tests on upstream PRs
+/no-rpm:
+    summary: Run tests independent of rpm
     discover+:
-        filter: tag:upstream
+        filter: tag:no-rpm
     adjust+:
-        enabled: false
-        when: initiator is not defined or initiator != packit
+        - enabled: false
+          when: initiator is not defined or initiator != packit
 
-/downstream:
-    summary: Run tests on bodhi / errata and dist-git PRs
+/rpm:
+    summary: Run tests on the rpm
     discover+:
-        filter: tag:downstream
-        dist-git-install-builddeps: true
-        dist-git-source: true
-        dist-git-remove-fmf-root: true
-    adjust+:
-        enabled: false
-        when: initiator == packit
+        filter: tag:rpm

--- a/rpm/aardvark-dns.spec
+++ b/rpm/aardvark-dns.spec
@@ -78,6 +78,10 @@ tar fx %{SOURCE1}
 %install
 %{__make} DESTDIR=%{buildroot} PREFIX=%{_prefix} install
 
+# Add empty check section to silence rpmlint warning.
+# No tests meant to be run here.
+%check
+
 %files
 %license LICENSE
 %if (0%{?fedora} || 0%{?rhel} >= 10) && !%{defined copr_username}

--- a/rpm/aardvark-dns.spec
+++ b/rpm/aardvark-dns.spec
@@ -53,6 +53,23 @@ BuildRequires: rust-srpm-macros
 Forwards other request to configured resolvers.
 Read more about configuration in `src/backend/mod.rs`.
 
+%package tests
+Summary: Tests for %{name}
+
+Requires: %{name} = %{epoch}:%{version}-%{release}
+Requires: bats
+Requires: bind-utils
+Requires: jq
+Requires: netavark
+Requires: nmap-ncat
+Requires: dnsmasq
+
+%description tests
+%{summary}
+
+This package contains system tests for %{name} and is only intended to be used
+for gating tests.
+
 %prep
 %autosetup -Sgit %{name}-%{version}
 # Following steps are only required on environments like koji which have no
@@ -78,6 +95,10 @@ tar fx %{SOURCE1}
 %install
 %{__make} DESTDIR=%{buildroot} PREFIX=%{_prefix} install
 
+%{__install} -d -p %{buildroot}%{_datadir}/%{name}/test
+%{__cp} -rp test/* %{buildroot}%{_datadir}/%{name}/test/
+%{__rm} -rf %{buildroot}%{_datadir}/%{name}/test/tmt/    
+
 # Add empty check section to silence rpmlint warning.
 # No tests meant to be run here.
 %check
@@ -90,6 +111,9 @@ tar fx %{SOURCE1}
 %endif
 %dir %{_libexecdir}/podman
 %{_libexecdir}/podman/%{name}
+
+%files tests
+%{_datadir}/%{name}/test
 
 %changelog
 %autochangelog

--- a/rpm/gating.yaml
+++ b/rpm/gating.yaml
@@ -1,7 +1,10 @@
 --- !Policy
 product_versions:
   - fedora-*
-decision_context: bodhi_update_push_stable
+decision_context:
+  - bodhi_update_push_stable
+  - bodhi_update_push_testing
+subject_type: koji_build
 rules:
   - !PassingTestCaseRule {test_case_name: fedora-ci.koji-build.tier0.functional}
 
@@ -9,4 +12,5 @@ rules:
 product_versions:
   - rhel-*
 decision_context: osci_compose_gate
-rules: []
+rules:
+  - !PassingTestCaseRule {test_case_name: osci.brew-build.tier0.functional}

--- a/test/tmt/main.fmf
+++ b/test/tmt/main.fmf
@@ -1,35 +1,26 @@
-# Only common dependencies that are NOT required to run netavark-tests.sh are
-# specified here. Everything else is in netavark-tests.sh.
-require:
-    - bats
-    - bind-utils
-    - cargo
-    - clippy
-    - go-md2man
-    - iptables
-    - jq
-    - make
-    - netavark
-    - nftables
-    - nmap-ncat
-    - rustfmt
-    - dnsmasq
-
-adjust:
-    duration: 10m
-    when: arch == aarch64
-
 /validate:
-    tag: upstream
+    tag: [ no-rpm, validate ]
     summary: Validate test
     test: make -C ../.. validate
+    require:
+        - clippy
+        - rustfmt
 
 /unit:
-    tag: upstream
-    summary: Unit test
+    tag: [ no-rpm, unit ]
+    summary: Unit tests
     test: make -C ../.. unit
+    require:
+        - cargo
 
 /integration:
-    tag: [ upstream, downstream]
+    tag: [ rpm, integration ]
     summary: Integration tests
     test: bash test_integration.sh
+    environment:
+        AARDVARK: /usr/libexec/podman/aardvark-dns
+    require:
+        - aardvark-dns-tests
+    adjust:
+        duration: 10m
+        when: arch == aarch64

--- a/test/tmt/test_integration.sh
+++ b/test/tmt/test_integration.sh
@@ -2,16 +2,7 @@
 
 set -exo pipefail
 
-# Remove testing-farm repos if they exist because they interfere with the
-# podman-next copr. The default distro repos will not be removed and can be
-# used wherever relevant.
-rm -f /etc/yum.repos.d/tag-repository.repo
+rpm -q aardvark-dns aardvark-dns-tests netavark
 
-# We want the netavark build from podman-next, so we update it after removing
-# testing-farm repo.
-dnf -y update netavark
-
-rpm -q aardvark-dns cargo netavark nftables
-
-# Run tests
-make -C ../.. AARDVARK=/usr/libexec/podman/aardvark-dns integration
+cd /usr/share/aardvark-dns/
+bats test/


### PR DESCRIPTION
This makes fetching and running of gating tests similar to podman, buildah and skopeo.