### PR TITLE
Add link to c/common contributor's guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing to Containers/aardvark
+
+We'd love to have you join the community! [Learn how to contribute](https://github.com/containers/common/blob/main/CONTRIBUTING.md) to the Containers Group Projects.

--- a/README.md
+++ b/README.md
@@ -48,3 +48,5 @@ RUST_LOG=trace ./bin/aardvark-dns --config src/test/config/podman/ --port 5533 r
 ```
 
 ### [Configuration file format](./config.md)
+
+### [Contributing](./CONTRIBUTING.md)


### PR DESCRIPTION
This PR adds a link to c/common contributor's guide. 

Fixes: https://issues.redhat.com/browse/RUN-2321

Note: After the merge https://github.com/containers/common/pull/2386, the contributor's guide will contain sections specific to Golang and Rust. 