### PR TITLE
deps: update nix to 0.30.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.29.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ hickory-proto = { version = "0.25.2", features = ["tokio"] }
 hickory-client = "0.25.2"
 futures-util = { version = "0.3.31", default-features = false }
 tokio = { version = "1.45.0", features = ["macros", "rt-multi-thread", "net", "signal"] }
-nix = { version = "0.29.0", features = ["fs", "signal", "net"] }
+nix = { version = "0.30.1", features = ["fs", "signal", "net"] }
 libc = "0.2.172"
 arc-swap = "1.7.1"
 flume = "0.11.1"

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -4,7 +4,6 @@ use clap::Parser;
 use nix::unistd;
 use nix::unistd::{fork, ForkResult};
 use std::io::Error;
-use std::os::unix::io::AsRawFd;
 
 #[derive(Parser, Debug)]
 pub struct Run {}
@@ -36,10 +35,10 @@ impl Run {
                 // child never sends message because it exited to early...
                 drop(ready_pipe_write);
                 // verify aardvark here and block till will start
-                let i = unistd::read(ready_pipe_read.as_raw_fd(), &mut [0_u8; 1])?;
+                let i = unistd::read(&ready_pipe_read, &mut [0_u8; 1])?;
                 drop(ready_pipe_read);
                 if i == 0 {
-                    // we did not get nay message -> child exited with error
+                    // we did not get any message -> child exited with error
                     Err(std::io::Error::new(
                         std::io::ErrorKind::Other,
                         "Error from child process",


### PR DESCRIPTION
The dup2 API has changed and now requires an OwnedFd as traget fd, that is not what we have or want. An OwnedFd is closed on drop so even if I would create one it would be dropped at the end of the function which would then close stdin/out/err which would be clearly wrong.

To accommodate the common use case of replacing the std stream nix added the dup2_stdin/stdout/stderr functions instead which we now use.

Also read no longer accepts a raw fd either.