### PR TITLE
ci: ensure build does not modify committed files

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -54,6 +54,7 @@ build_task:
     reupload_on_changes: true
   setup_script: &setup "$SCRIPT_BASE/setup.sh $CIRRUS_TASK_NAME"
   main_script: &main "$SCRIPT_BASE/runner.sh $CIRRUS_TASK_NAME"
+  postbuild_script: &postbuild hack/tree_status.sh
   # N/B: This script comes from `main` on the netavark repo
   cache_grooming_script: &groom bash "$SCRIPT_BASE/netavark_cache_groom.sh"
   upload_caches: [ "cargo", "targets", "bin" ]
@@ -78,6 +79,7 @@ build_aarch64_task:
     fingerprint_key: "cargo_v1_${DEST_BRANCH}_aarch64"
   setup_script: *setup
   main_script: *main
+  postbuild_script: *postbuild
   cache_grooming_script: *groom
   upload_caches: [ "cargo", "targets", "bin" ]
   # Downstream CI needs the aarch64 binaries from this CI system.

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ GIT_TAG ?= $(shell git describe --tags)
 # build w/ debugging features.
 debug ?=
 
-# Set path to cargo executable
-CARGO ?= cargo
+# Set path to cargo executable, when running under CI make sure to add --locked so Cargo.lock is not modified
+CARGO ?= cargo $(if $(CI),--locked,)
 
 # All complication artifacts, including dependencies and intermediates
 # will be stored here, for all architectures.  Use a non-default name

--- a/hack/tree_status.sh
+++ b/hack/tree_status.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+STATUS=$(git status --porcelain)
+if [[ -z $STATUS ]]
+then
+	echo "tree is clean"
+else
+	echo "tree is dirty"
+	echo ""
+	echo "$STATUS"
+	echo ""
+	echo "---------------------- Diff below ----------------------"
+	echo ""
+	git --no-pager diff
+	exit 1
+fi
+


### PR DESCRIPTION
ci: ensure tree is clean after build

To ensure Cargo.lock or other files that are committed are not modified
by the build in CI.

---

Makefile: use cargo --locked in CI

CI should never modify the lockfile so add --locked when running under
CI, the CI env is always defined by cirrus.

https://doc.rust-lang.org/cargo/commands/cargo.html#manifest-options

(like the netavark PR https://github.com/containers/netavark/pull/1233)