### PR TITLE
fix github release action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ targets/
 *.swp
 netavark.1
 vendor/
+vendor-tarball/

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ crate-publish:
 .PHONY: clean
 clean:
 	rm -rf bin
+	rm -rf vendor-tarball
 	if [ "$(CARGO_TARGET_DIR)" = "targets" ]; then rm -rf targets; fi
 	$(MAKE) -C docs clean
 
@@ -120,8 +121,10 @@ validate: $(CARGO_TARGET_DIR)
 vendor-tarball: build install.cargo-vendor-filterer
 	VERSION=$(shell bin/aardvark-dns --version | cut -f2 -d" ") && \
 	$(CARGO) vendor-filterer --format=tar.gz --prefix vendor/ && \
-	mv vendor.tar.gz aardvark-dns-v$$VERSION-vendor.tar.gz && \
-	gzip -c bin/aardvark-dns > aardvark-dns.gz && \
+	mkdir -p vendor-tarball && \
+	mv vendor.tar.gz vendor-tarball/aardvark-dns-v$$VERSION-vendor.tar.gz && \
+	gzip -c bin/aardvark-dns > vendor-tarball/aardvark-dns.gz && \
+	cd vendor-tarball && \
 	sha256sum aardvark-dns.gz aardvark-dns-v$$VERSION-vendor.tar.gz > sha256sum
 
 .PHONY: install.cargo-vendor-filterer


### PR DESCRIPTION
The make target like done in netavark should put the files into the vendor-tarball directory.

Fixes: ce41695 ("github: add automatic release action")