### PR TITLE
make more use of AardvarkError

### DIFF
--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -1,6 +1,5 @@
 use clap::Parser;
 use std::fmt;
-use std::io::Error;
 
 #[derive(Parser, Debug)]
 pub struct Version {}
@@ -30,7 +29,7 @@ impl fmt::Display for Info {
 }
 
 impl Version {
-    pub fn exec(&self) -> Result<(), Error> {
+    pub fn exec(&self) {
         let info = Info {
             version: env!("CARGO_PKG_VERSION"),
             commit: env!("GIT_COMMIT"),
@@ -38,7 +37,5 @@ impl Version {
             target: env!("BUILD_TARGET"),
         };
         println!("{}", info);
-
-        Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,10 @@ fn main() {
         .unwrap_or_else(|| String::from(".dns.podman"));
     let result = match opts.subcmd {
         SubCommand::Run(run) => run.exec(dir, port, filter_search_domain),
-        SubCommand::Version(version) => version.exec(),
+        SubCommand::Version(version) => {
+            version.exec();
+            Ok(())
+        }
     };
 
     match result {

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -34,26 +34,26 @@ use std::process;
 type ThreadHandleMap<Ip> =
     HashMap<(String, Ip), (flume::Sender<()>, JoinHandle<AardvarkResult<()>>)>;
 
-pub fn create_pid(config_path: &str) -> Result<(), std::io::Error> {
+pub fn create_pid(config_path: &str) -> AardvarkResult<()> {
     // before serving write its pid to _config_path so other process can notify
     // aardvark of data change.
     let path = Path::new(config_path).join(AARDVARK_PID_FILE);
     let mut pid_file = match File::create(path) {
         Err(err) => {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("Unable to get process pid: {}", err),
-            ));
+            return Err(AardvarkError::msg(format!(
+                "Unable to get process pid: {}",
+                err
+            )));
         }
         Ok(file) => file,
     };
 
     let server_pid = process::id().to_string();
     if let Err(err) = pid_file.write_all(server_pid.as_bytes()) {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!("Unable to write pid to file: {}", err),
-        ));
+        return Err(AardvarkError::msg(format!(
+            "Unable to write pid to file: {}",
+            err
+        )));
     }
 
     Ok(())


### PR DESCRIPTION
A clippy lint[1] wants us to use the other() function on the io error. However we already have our own error type for custom messages so just use that and no co-opt the std::io::Error type.

[1] https://rust-lang.github.io/rust-clippy/master/index.html#io_other_error