### PR TITLE
fix new rust 1.88 lint errors

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -26,5 +26,5 @@ fn main() {
         // if error, e.g. build from source with git repo, just show empty string
         Err(_) => "".to_string(),
     };
-    println!("cargo:rustc-env=GIT_COMMIT={}", commit);
+    println!("cargo:rustc-env=GIT_COMMIT={commit}");
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -98,7 +98,7 @@ impl DNSBackend {
             let net_names = match self.name_mappings.get(net) {
                 Some(n) => n,
                 None => {
-                    error!("Container with IP {} belongs to network {} but there is no listing in networks table!", requester, net);
+                    error!("Container with IP {requester} belongs to network {net} but there is no listing in networks table!");
                     continue;
                 }
             };

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -30,7 +30,7 @@ impl Run {
         // setsid() ensures that there is no controlling terminal on the child process
         match unsafe { fork() } {
             Ok(ForkResult::Parent { child, .. }) => {
-                log::debug!("starting aardvark on a child with pid {}", child);
+                log::debug!("starting aardvark on a child with pid {child}");
                 // close write here to make sure the read does not hang when
                 // child never sends message because it exited to early...
                 drop(ready_pipe_write);
@@ -49,24 +49,20 @@ impl Run {
                 // create aardvark pid and then notify parent
                 if let Err(er) = serve::create_pid(&input_dir) {
                     return Err(AardvarkError::msg(format!(
-                        "Error creating aardvark pid {}",
-                        er
+                        "Error creating aardvark pid {er}"
                     )));
                 }
 
                 if let Err(er) =
                     serve::serve(&input_dir, port, &filter_search_domain, ready_pipe_write)
                 {
-                    return Err(AardvarkError::msg(format!("Error starting server {}", er)));
+                    return Err(AardvarkError::msg(format!("Error starting server {er}")));
                 }
                 Ok(())
             }
             Err(err) => {
-                log::debug!("fork failed with error {}", err);
-                Err(AardvarkError::msg(format!(
-                    "fork failed with error: {}",
-                    err
-                )))
+                log::debug!("fork failed with error {err}");
+                Err(AardvarkError::msg(format!("fork failed with error: {err}")))
             }
         }
     }

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -36,6 +36,6 @@ impl Version {
             build_time: env!("BUILD_TIMESTAMP"),
             target: env!("BUILD_TARGET"),
         };
-        println!("{}", info);
+        println!("{info}");
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -30,8 +30,7 @@ pub fn parse_configs(
 )> {
     if !metadata(dir)?.is_dir() {
         return Err(AardvarkError::msg(format!(
-            "config directory {} must exist and be a directory",
-            dir
+            "config directory {dir} must exist and be a directory"
         )));
     }
 
@@ -192,7 +191,7 @@ pub fn parse_configs(
             }
             Err(e) => {
                 if e.kind() != std::io::ErrorKind::NotFound {
-                    error!("Error listing config file for server update: {}", e)
+                    error!("Error listing config file for server update: {e}")
                 }
             }
         }
@@ -211,9 +210,8 @@ pub fn parse_configs(
             }
             None => {
                 return Err(AardvarkError::msg(format!(
-                    "Container ID {} has an entry in IPs table, but not network membership table",
-                    ctr_id
-                )))
+                "Container ID {ctr_id} has an entry in IPs table, but not network membership table"
+            )))
             }
         }
     }
@@ -279,8 +277,7 @@ fn parse_config(path: &std::path::Path) -> AardvarkResult<ParsedNetworkConfig> {
                     Ok(l) => l,
                     Err(e) => {
                         return Err(AardvarkError::msg(format!(
-                            "error parsing ip address {}: {}",
-                            ip, e
+                            "error parsing ip address {ip}: {e}"
                         )))
                     }
                 };
@@ -296,8 +293,7 @@ fn parse_config(path: &std::path::Path) -> AardvarkResult<ParsedNetworkConfig> {
                         Ok(l) => l,
                         Err(e) => {
                             return Err(AardvarkError::msg(format!(
-                                "error parsing network dns address {}: {}",
-                                ip, e
+                                "error parsing network dns address {ip}: {e}"
                             )))
                         }
                     };

--- a/src/dns/coredns.rs
+++ b/src/dns/coredns.rs
@@ -129,8 +129,7 @@ impl CoreDns {
                 }
             }
             Err(_) => debug!(
-                "Tcp connection {} was cancelled after 3s as it took to long to receive message",
-                peer
+                "Tcp connection {peer} was cancelled after 3s as it took to long to receive message"
             ),
         }
     }
@@ -144,7 +143,7 @@ impl CoreDns {
         let msg = match msg_received {
             Ok(msg) => msg,
             Err(e) => {
-                error!("Error parsing dns message {:?}", e);
+                error!("Error parsing dns message {e:?}");
                 return;
             }
         };
@@ -162,8 +161,8 @@ impl CoreDns {
 
         // Create debug and trace info for key parameters.
         trace!("server network name: {:?}", data.network_name);
-        debug!("request source address: {:?}", src_address);
-        trace!("requested record type: {:?}", record_type);
+        debug!("request source address: {src_address:?}");
+        trace!("requested record type: {record_type:?}");
         debug!(
             "checking if backend has entry for: {:?}",
             &request_name_string
@@ -327,10 +326,10 @@ fn reply(sender: &mut BufDnsStreamHandle, socket_addr: SocketAddr, msg: &Message
 
     match sender.send(response) {
         Ok(_) => {
-            debug!("[{}] success reponse", id);
+            debug!("[{id}] success reponse");
         }
         Err(e) => {
-            error!("[{}] fail response: {:?}", id, e);
+            error!("[{id}] fail response: {e:?}");
         }
     }
 
@@ -358,12 +357,12 @@ fn parse_dns_msg(body: SerialMessage) -> Option<(Name, RecordType, Message)> {
                 msg.extensions().is_some(),
             );
 
-            debug!("parsed message {:?}", parsed_msg);
+            debug!("parsed message {parsed_msg:?}");
 
             Some((name, record_type, msg))
         }
         Err(e) => {
-            warn!("Failed while parsing message: {}", e);
+            warn!("Failed while parsing message: {e}");
             None
         }
     }
@@ -390,11 +389,11 @@ async fn forward_dns_req(cl: Client, message: Message) -> Option<Message> {
             Some(response_message)
         }
         Ok(None) => {
-            error!("{} dns request got empty response", id);
+            error!("{id} dns request got empty response");
             None
         }
         Err(e) => {
-            error!("{} dns request failed: {}", id, e);
+            error!("{id} dns request failed: {e}");
             None
         }
     }
@@ -439,7 +438,7 @@ fn reply_ptr(
         if let Some(reverse_lookup) = backend.reverse_lookup(&src_address.ip(), &lookup_ip) {
             let mut req_clone = req.clone();
             for entry in reverse_lookup {
-                if let Ok(answer) = Name::from_ascii(format!("{}.", entry)) {
+                if let Ok(answer) = Name::from_ascii(format!("{entry}.")) {
                     let record = Record::<RData>::from_rdata(
                         Name::from_str_relaxed(name).unwrap_or_default(),
                         0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ fn main() {
         Ok(val) => match Level::from_str(&val) {
             Ok(level) => level,
             Err(e) => {
-                eprintln!("failed to parse RUST_LOG level: {}", e);
+                eprintln!("failed to parse RUST_LOG level: {e}");
                 Level::Info
             }
         },
@@ -58,7 +58,7 @@ fn main() {
         if let Err(e) = log::set_boxed_logger(Box::new(BasicLogger::new(logger)))
             .map(|()| log::set_max_level(log_level.to_level_filter()))
         {
-            eprintln!("failed to initialize syslog logger: {}", e)
+            eprintln!("failed to initialize syslog logger: {e}")
         };
     }
 

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -41,8 +41,7 @@ pub fn create_pid(config_path: &str) -> AardvarkResult<()> {
     let mut pid_file = match File::create(path) {
         Err(err) => {
             return Err(AardvarkError::msg(format!(
-                "Unable to get process pid: {}",
-                err
+                "Unable to get process pid: {err}"
             )));
         }
         Ok(file) => file,
@@ -51,8 +50,7 @@ pub fn create_pid(config_path: &str) -> AardvarkResult<()> {
     let server_pid = process::id().to_string();
     if let Err(err) = pid_file.write_all(server_pid.as_bytes()) {
         return Err(AardvarkError::msg(format!(
-            "Unable to write pid to file: {}",
-            err
+            "Unable to write pid to file: {err}"
         )));
     }
 
@@ -227,11 +225,11 @@ async fn stop_threads<Ip>(
                 // result returned by the future, i.e. that actual
                 // result from start_dns_server()
                 if let Err(e) = res {
-                    error!("Error from dns server: {}", e)
+                    error!("Error from dns server: {e}")
                 }
             }
             // error from tokio itself
-            Err(e) => error!("Error from dns server task: {}", e),
+            Err(e) => error!("Error from dns server task: {e}"),
         }
     }
 }
@@ -276,8 +274,8 @@ async fn read_config_and_spawn(
     };
 
     debug!("Successfully parsed config");
-    debug!("Listen v4 ip {:?}", listen_ip_v4);
-    debug!("Listen v6 ip {:?}", listen_ip_v6);
+    debug!("Listen v4 ip {listen_ip_v4:?}");
+    debug!("Listen v6 ip {listen_ip_v6:?}");
 
     // kill server if listen_ip's are empty
     if listen_ip_v4.is_empty() && listen_ip_v6.is_empty() {
@@ -359,7 +357,7 @@ fn daemonize() -> Result<(), Error> {
         .read(true)
         .write(true)
         .open("/dev/null")
-        .map_err(|e| std::io::Error::new(e.kind(), format!("/dev/null: {:#}", e)))?;
+        .map_err(|e| std::io::Error::new(e.kind(), format!("/dev/null: {e:#}")))?;
     // redirect stdout, stdin and stderr to /dev/null
     let _ = dup2_stdin(&dev_null);
     let _ = dup2_stdout(&dev_null);


### PR DESCRIPTION
Just some slight formatting for the format!() macros. I migrated them using cargo clippy --fix.