### PR TITLE
coredns: process more than one message per tcp connection

### DIFF
--- a/src/dns/coredns.rs
+++ b/src/dns/coredns.rs
@@ -130,7 +130,7 @@ impl CoreDns {
                 },
                 Err(_) => {
                     debug!(
-                        "Tcp connection {peer} was cancelled after 3s as it took to long to receive message"
+                        "Tcp connection {peer} was cancelled after 3s as it took too long to receive message"
                     );
                     break;
                 }

--- a/src/dns/coredns.rs
+++ b/src/dns/coredns.rs
@@ -117,20 +117,24 @@ impl CoreDns {
         let (mut hickory_stream, sender_original) =
             TcpStream::from_stream(AsyncIoTokioAsStd(stream), peer);
 
-        // It is possible for a client to keep the tcp socket open forever and never send any data,
-        // we do not want this so add a 3s timeout then we close the socket.
-        match tokio::time::timeout(Duration::from_secs(3), hickory_stream.next()).await {
-            Ok(message) => {
-                if let Some(msg) = message {
-                    Self::process_message(&data, msg, &sender_original, Protocol::Tcp).await;
-                    // The API is a bit strange, first time we call next we get the message,
-                    // but we must call again to send our reply back
-                    hickory_stream.next().await;
+        loop {
+            // It is possible for a client to keep the tcp socket open forever and never send any data,
+            // we do not want this so add a 3s timeout then we close the socket.
+            match tokio::time::timeout(Duration::from_secs(3), hickory_stream.next()).await {
+                Ok(message) => match message {
+                    Some(msg) => {
+                        Self::process_message(&data, msg, &sender_original, Protocol::Tcp).await
+                    }
+                    // end of stream
+                    None => break,
+                },
+                Err(_) => {
+                    debug!(
+                        "Tcp connection {peer} was cancelled after 3s as it took to long to receive message"
+                    );
+                    break;
                 }
             }
-            Err(_) => debug!(
-                "Tcp connection {peer} was cancelled after 3s as it took to long to receive message"
-            ),
         }
     }
 

--- a/test/100-basic-name-resolution.bats
+++ b/test/100-basic-name-resolution.bats
@@ -117,6 +117,12 @@ function teardown() {
 	run_in_container_netns "$a1_pid" "dig" "+tcp" "+short" "aone" "@$gw"
 	assert "$ip_a1"
 
+	# check multiple TCP requests over single connecting by using +keepopen
+	# https://github.com/containers/aardvark-dns/issues/605
+	run_in_container_netns "$a1_pid" "dig" "+tcp" "+short" +keepopen "@$gw" "aone" "a1" "1a"
+	assert "${lines[0]}" == "$ip_a1" "ip for aone"
+	assert "${lines[1]}" == "$ip_a1" "ip for a1"
+	assert "${lines[2]}" == "$ip_a1" "ip for 1a"
 
 	run_in_container_netns "$a1_pid" "dig" "+short" "$TEST_DOMAIN" "@$gw"
 	# validate that we get an ipv4


### PR DESCRIPTION
DNS over TCP allows for multiple requests per connection. Right now we only processed the first one which seems to cause problems for the glibc resolver.

Fix this by allowing multiple requests, however we still keep our 3s timeout per message so if the connection is unused for longer we still close it to avoid keep to many connections open at the same time.

Fixes: #605
Fixes: https://issues.redhat.com/browse/RHEL-104209

## Summary by Sourcery

Enable processing of multiple DNS messages over a single TCP connection while retaining a per-message timeout to prevent idle connections from lingering.

New Features:
- Allow CoreDNS to handle multiple DNS-over-TCP requests on the same connection

Enhancements:
- Retain a 3-second timeout for each TCP message to avoid excessive open connections

Tests:
- Add a bats test using dig +keepopen to verify multiple TCP queries are served correctly