### PR TITLE
test: Remove empty user= directive in dnsmasq.conf to avoid SIGSEGV

### DIFF
--- a/test/dnsmasq.conf
+++ b/test/dnsmasq.conf
@@ -6,8 +6,6 @@ no-resolv
 
 log-queries
 
-user=
-
 # aone and bone should return NXDOMAIN, by default dnsmasq returns REFUSED
 address=/aone/
 address=/bone/


### PR DESCRIPTION
Remove empty user= directive in dnsmasq.conf to avoid SIGSEGV

Fixes https://github.com/containers/aardvark-dns/issues/618

Verification runs (openSUSE Tumbleweed):
- aarch64: https://openqa.opensuse.org/tests/5231401
- x86_64: https://openqa.opensuse.org/tests/5231402

All previously ignored tests (100-basic-name-resolution 200-two-networks 300-three-networks) are now enabled in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22928

## Summary by Sourcery

Remove the empty user= directive from the test dnsmasq configuration to prevent segfaults when running aardvark-dns, as reported in issue #618.

Bug Fixes:
- Remove empty user= line in dnsmasq.conf to avoid SIGSEGV

Tests:
- Verify no core dumps are generated
- Confirm 200-two-networks and 300-three-networks tests now pass