### PR TITLE
test: replace ncat with socat

### DIFF
--- a/rpm/aardvark-dns.spec
+++ b/rpm/aardvark-dns.spec
@@ -61,7 +61,7 @@ Requires: bats
 Requires: bind-utils
 Requires: jq
 Requires: netavark
-Requires: nmap-ncat
+Requires: socat
 Requires: dnsmasq
 
 %description tests
@@ -97,7 +97,7 @@ tar fx %{SOURCE1}
 
 %{__install} -d -p %{buildroot}%{_datadir}/%{name}/test
 %{__cp} -rp test/* %{buildroot}%{_datadir}/%{name}/test/
-%{__rm} -rf %{buildroot}%{_datadir}/%{name}/test/tmt/    
+%{__rm} -rf %{buildroot}%{_datadir}/%{name}/test/tmt/
 
 # Add empty check section to silence rpmlint warning.
 # No tests meant to be run here.

--- a/test/100-basic-name-resolution.bats
+++ b/test/100-basic-name-resolution.bats
@@ -74,8 +74,8 @@ function teardown() {
 @test "basic container - dns itself (bad and good should fall back)" {
 	setup_dnsmasq
 
-	# using sh-exec to keep the udp query hanging for at least 3 seconds
-	nsenter -m -n -t $HOST_NS_PID ncat -l -u 127.5.5.5 53 --sh-exec "sleep 3" 3>/dev/null &
+	# using exec to keep the udp query hanging for at least 3 seconds
+	nsenter -m -n -t $HOST_NS_PID socat UDP4-LISTEN:53,bind=127.5.5.5 EXEC:"sleep 3" 3>/dev/null &
 	HELPER_PID=$!
 
 	subnet_a=$(random_subnet 5)
@@ -90,8 +90,9 @@ function teardown() {
 	run_in_container_netns "$a1_pid" "dig" "$TEST_DOMAIN" "@$gw"
 	assert "$output" =~ "Query time: [23][0-9]{3} msec" "timeout should be 2.5s so request should then work shortly after (udp)"
 
+	kill -9 "$HELPER_PID" || true
 	# Now the same with tcp.
-	nsenter -m -n -t $HOST_NS_PID ncat -l 127.5.5.5 53 --sh-exec "sleep 3" 3>/dev/null &
+	nsenter -m -n -t $HOST_NS_PID socat TCP4-LISTEN:53,bind=127.5.5.5 EXEC:"sleep 3" 3>/dev/null &
 	HELPER_PID=$!
 	run_in_container_netns "$a1_pid" "dig" +tcp "$TEST_DOMAIN" "@$gw"
 	assert "$output" =~ "Query time: [23][0-9]{3} msec" "timeout should be 2.5s so request should then work shortly after (tcp)"

--- a/test/600-errors.bats
+++ b/test/600-errors.bats
@@ -6,10 +6,10 @@
 load helpers
 
 
-NCPID=
+SOCAT_PID=
 
 function teardown() {
-    kill -9 $NCPID
+    kill -9 $SOCAT_PID
     basic_teardown
 }
 
@@ -17,10 +17,10 @@ function teardown() {
 @test "aardvark-dns should fail when udp port is already bound" {
 	# bind the port to force a failure for aardvark-dns
 	# we cannot use run_is_host_netns to run in the background
-	nsenter -m -n -t $HOST_NS_PID ncat -u -l 0.0.0.0 53 </dev/null 3> /dev/null &
-	NCPID=$!
+	nsenter -m -n -t $HOST_NS_PID socat UDP4-LISTEN:53 - 3> /dev/null &
+	SOCAT_PID=$!
 
-	# ensure nc has time to bind the port
+	# ensure socat has time to bind the port
 	sleep 1
 
 	subnet_a=$(random_subnet 5)
@@ -33,10 +33,10 @@ function teardown() {
 @test "aardvark-dns should fail when tcp port is already bound" {
 	# bind the port to force a failure for aardvark-dns
 	# we cannot use run_is_host_netns to run in the background
-	nsenter -m -n -t $HOST_NS_PID ncat -l 0.0.0.0 53 </dev/null 3> /dev/null &
-	NCPID=$!
+	nsenter -m -n -t $HOST_NS_PID socat TCP4-LISTEN:53 - 3> /dev/null &
+	SOCAT_PID=$!
 
-	# ensure nc has time to bind the port
+	# ensure socat has time to bind the port
 	sleep 1
 
 	subnet_a=$(random_subnet 5)


### PR DESCRIPTION
ncat keeps causing issues with different versions having different
behaviors. And many distro ship different incompatible versions so it is
hard to make the test work everywhere consistently.

To address replace ncat with socat. Socat seems to much more stable and
we have been using it in podman for pasta tests for a while without
problems.

Fixes: #622