### PR TITLE
bats: remove fd 3 work around

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -51,9 +51,7 @@ function run_helper() {
     # stdout is only emitted upon error; this echo is to help a debugger
     echo "$_LOG_PROMPT $*"
 
-    # BATS hangs if a subprocess remains and keeps FD 3 open; this happens
-    # if a process crashes unexpectedly without cleaning up subprocesses.
-    run timeout --foreground -v --kill=10 10 "$@" 3>&-
+    run timeout --foreground -v --kill=10 10 "$@"
     # without "quotes", multiple lines are glommed together into one
     if [ -n "$output" ]; then
         echo "$output"


### PR DESCRIPTION
Do not close fd3 for the run call, bats needs it to report proper errors. If run fails, i.e. due a missing command, bats only reports "Executed 0 instead of expected 1 tests" as it failed writing to fd3.

The comment hints at a old hang when sub processes got leaked. This may be a relict of the past, when I added some background sleep I confirmed that bats still completed fine.

This problem was reported by Reinhard Tartler.