### PR TITLE
Packit: Only create dist-git PRs for rawhide

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -123,12 +123,16 @@ jobs:
             id: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/repo/centos-stream-$releasever/rhcontainerbot-podman-next-centos-stream-$releasever.repo
 
   # Sync to Fedora
+  # NOTE: Breaking changes related to Podman6 will only be shipped to Fedora
+  # Rawhide (to be Fedora 45) and newer.
+  # TODO: Update dist_git_branches as and when new Fedora releases are
+  # available.
   - job: propose_downstream
     trigger: release
     packages: [aardvark-dns-fedora]
     update_release: false
     dist_git_branches: &fedora_targets
-      - fedora-all
+      - fedora-rawhide
 
   # Sync to CentOS Stream
   - job: propose_downstream


### PR DESCRIPTION
We'll only be releasing breaking changes on rawhide so dist-git PRs should only be created for rawhide.