### PR TITLE
close inherited file descriptors on startup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,9 @@ enum SubCommand {
 }
 
 fn main() {
+    // Close all fds we inherited from our parent process, we only need stdio.
+    let _ = unsafe { libc::close_range(3, libc::c_uint::MAX, 0) };
+
     let formatter = Formatter3164 {
         facility: Facility::LOG_USER,
         hostname: None,

--- a/test/700-process-startup.bats
+++ b/test/700-process-startup.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats   -*- bats -*-
+#
+# test aardvark-dns process startup
+#
+
+bats_require_minimum_version 1.5.0
+load helpers
+
+@test "closes inherited file descriptors" {
+	local marker="$AARDVARK_TMPDIR/fd-marker"
+	exec 9>"$marker"
+
+	subnet_a=$(random_subnet 5)
+	create_config network_name="podman1" container_id=$(random_string 64) container_name="aone" subnet="$subnet_a"
+	create_container "$config"
+
+	exec 9>&-
+
+	local aardvark_pid
+	aardvark_pid=$(cat "$AARDVARK_TMPDIR/aardvark-dns/aardvark.pid")
+	assert "$aardvark_pid" != ""
+
+	run -0 readlink /proc/$aardvark_pid/fd/*
+	assert "$output" =~ "/dev/null"
+	assert "$output" !~ "fd-marker"
+}


### PR DESCRIPTION
aardvark-dns is `exec`'d by netavark and inherits all of its parent's open fds. As a long-running daemon it holds that fd for its entire lifetime, so an inherited socket (e.g. a systemd socket-activation fd) stays bound even after the socket unit is stopped, and restarting it fails with `Address already in use`.

We only ever need stdio, so close every fd above stderr on startup with `close_range()` (Happy to be corrected if there's an inherited fd we're expected to keep).

Note that `close_range()` needs Linux 5.9+. On older kernels it returns `ENOSYS`, which we ignore, so the fix silently does nothing there and behaviour is unchanged.

Let me know if I should add a test for this.

Fixes: https://github.com/containers/podman/issues/27854
