### PR TITLE
fix new lint warnings in 1.97

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -119,19 +119,15 @@ impl DNSBackend {
     pub fn get_network_scoped_resolvers(&self, requester: &IpAddr) -> Option<Vec<IpAddr>> {
         let mut results: Vec<IpAddr> = Vec::new();
 
-        match self.ip_mappings.get(requester) {
-            Some(nets) => {
-                for net in nets {
-                    match self.network_dns_server.get(net) {
-                        Some(resolvers) => results.extend_from_slice(resolvers),
-                        None => {
-                            continue;
-                        }
-                    };
+        let nets = self.ip_mappings.get(requester)?;
+        for net in nets {
+            match self.network_dns_server.get(net) {
+                Some(resolvers) => results.extend_from_slice(resolvers),
+                None => {
+                    continue;
                 }
-            }
-            None => return None,
-        };
+            };
+        }
 
         Some(results)
     }

--- a/src/dns/coredns.rs
+++ b/src/dns/coredns.rs
@@ -176,7 +176,7 @@ impl CoreDns {
         trace!("requested record type: {record_type:?}");
         debug!(
             "checking if backend has entry for: {:?}",
-            &request_name_string
+            request_name_string
         );
         trace!("server backend.name_mappings: {:?}", backend.name_mappings);
         trace!("server backend.ip_mappings: {:?}", backend.ip_mappings);
@@ -223,7 +223,7 @@ impl CoreDns {
         } else {
             debug!(
                 "Forwarding dns request for {} type: {}",
-                &request_name_string, record_type
+                request_name_string, record_type
             );
             let mut nameservers = Vec::new();
             // Add resolvers configured for container
@@ -411,33 +411,26 @@ fn reply_ptr(
     src_address: SocketAddr,
     req: &Message,
 ) -> Option<Message> {
-    let ptr_lookup_ip: String;
     // Are we IPv4 or IPv6?
-
-    match name.strip_suffix(".in-addr.arpa.") {
-        Some(n) => ptr_lookup_ip = n.split('.').rev().collect::<Vec<&str>>().join("."),
+    let ptr_lookup_ip = match name.strip_suffix(".in-addr.arpa.") {
+        Some(n) => n.split('.').rev().collect::<Vec<&str>>().join("."),
         None => {
             // not ipv4
-            match name.strip_suffix(".ip6.arpa.") {
-                Some(n) => {
-                    // ipv6 string is 39 chars max
-                    let mut tmp_ip = String::with_capacity(40);
-                    for (i, c) in n.split('.').rev().enumerate() {
-                        tmp_ip.push_str(c);
-                        // insert colon after 4 hex chars but not at the end
-                        if i % 4 == 3 && i < 31 {
-                            tmp_ip.push(':');
-                        }
-                    }
-                    ptr_lookup_ip = tmp_ip;
+            let n = name.strip_suffix(".ip6.arpa.")?;
+            // ipv6 string is 39 chars max
+            let mut tmp_ip = String::with_capacity(40);
+            for (i, c) in n.split('.').rev().enumerate() {
+                tmp_ip.push_str(c);
+                // insert colon after 4 hex chars but not at the end
+                if i % 4 == 3 && i < 31 {
+                    tmp_ip.push(':');
                 }
-                // neither ipv4 or ipv6, something we do not understand
-                None => return None,
             }
+            tmp_ip
         }
-    }
+    };
 
-    trace!("Performing reverse lookup for ip: {}", &ptr_lookup_ip);
+    trace!("Performing reverse lookup for ip: {}", ptr_lookup_ip);
 
     // We should probably log malformed queries, but for now if-let should be fine.
     if let Ok(lookup_ip) = ptr_lookup_ip.parse() {

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -88,7 +88,7 @@ pub async fn serve(
     // We are ready now, this is far from perfect we should at least wait for the first bind
     // to work but this is not really possible with the current code flow and needs more changes.
     daemonize()?;
-    let msg: [u8; 1] = [b'1'];
+    let msg: [u8; 1] = *b"1";
     unistd::write(&ready, &msg)?;
     drop(ready);
 
@@ -307,7 +307,7 @@ async fn read_config_and_spawn(
 
         let path = Path::new(config_path).join(AARDVARK_PID_FILE);
         if let Err(err) = fs::remove_file(path) {
-            error!("failed to remove the pid file: {}", &err);
+            error!("failed to remove the pid file: {}", err);
             process::exit(1);
         }
 


### PR DESCRIPTION
A few minor lint fixes for useless_borrows_in_formatting, question_mark and byte_char_slices.